### PR TITLE
Fix:增加不截图识别的debug信息和修复升级界面识别

### DIFF
--- a/command/get_position.py
+++ b/command/get_position.py
@@ -248,9 +248,9 @@ def get_pic_position_without_cap(img_model_path, precision=0.8, scale=0, screens
         # 获取匹配区域的中心点
         top_left = max_loc
         center_pos = (int(top_left[0] + w / 2), int(top_left[1] + h / 2))
-        msg = f"获取到图片{img_model_path}的中心点在截屏的位置:({center_pos[0]},{center_pos[1]})"
+        msg = f"获取到图片{img_model_path}的中心点在截屏的位置:({center_pos[0]},{center_pos[1]}),相似度为{max_val:.3f}"
         my_log("debug", msg)
         return center_pos
-    msg = f"未能获取到图片{img_model_path}的位置)"
+    msg = f"未能获取到图片{img_model_path}的位置),最大相似度{max_val:.3f}"
     my_log("debug", msg)
     return None

--- a/script/in_battle.py
+++ b/script/in_battle.py
@@ -128,11 +128,6 @@ def battle():
                     mouse_click(get_pic_position("./pic/battle/setting.png"))
                 mouse_click(get_pic_position("./pic/battle/give_up.png"))
                 break
-        # 如果交战过程误触，导致战斗暂停
-        elif get_pic_position("./pic/battle/continue.png"):
-            mouse_click(get_pic_position("./pic/battle/continue.png"))
-            chance = INIT_CHANCE
-            continue
         # 两种升级可能出现的图片识别
         elif get_pic_position("./pic/battle/level_up_message.png"):
             level_up_leave()
@@ -142,6 +137,11 @@ def battle():
             level_up_leave()
             chance = INIT_CHANCE
             continue
+        # 如果交战过程误触，导致战斗暂停
+        elif get_pic_position("./pic/battle/continue.png"):
+            mouse_click(get_pic_position("./pic/battle/continue.png"))
+            chance = INIT_CHANCE
+            continue        
         # 如果网络波动，需要点击重试
         elif get_pic_position("./pic/scenes/network/retry_countdown.png"):
             sleep(5)


### PR DESCRIPTION
- 向``get_pic_position_without_cap``函数内增加了打印识别度的debug信息
- 调整识别顺序尝试修复 https://github.com/KIYI671/AhabAssistantLimbusCompany/issues/72 中提到的bug