### PR TITLE
Doc:升级过时的构建指南

### DIFF
--- a/doc/en/build_guide_EN.md
+++ b/doc/en/build_guide_EN.md
@@ -25,8 +25,7 @@ mkdir dist_release
 mv dist/* dist_release/
 cp -r 3rdparty dist_release/AALC/
 cp -r pic dist_release/AALC/
-cp config.yaml dist_release/AALC/
-cp black_list_keyword.yaml dist_release/AALC/
+cp -r doc dist_release/AALC/
 cp LICENSE dist_release/AALC/
 cp README.md dist_release/AALC/
 ```

--- a/doc/zh/build_guide.md
+++ b/doc/zh/build_guide.md
@@ -25,8 +25,7 @@ mkdir dist_release
 mv dist/* dist_release/
 cp -r 3rdparty dist_release/AALC/
 cp -r pic dist_release/AALC/
-cp config.yaml dist_release/AALC/
-cp black_list_keyword.yaml dist_release/AALC/
+cp -r doc dist_release/AALC/
 cp LICENSE dist_release/AALC/
 cp README.md dist_release/AALC/
 ```


### PR DESCRIPTION
- 更新了中英版本的构建指南

CD经过几个版本的修改有所变化，但是构建指南一直没动。还是小修一下吧

碎碎念：
最近没刷镜牢推主线去了，就没怎么看aalc的开发。毕竟第六章都没过完连困牢都没解锁感觉不太好（逃ε=ε=ε=┏(゜ロ゜;)┛