### PR TITLE
Feature:增加了部分鼠标操作的moveback配置

### DIFF
--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -73,19 +73,20 @@ class Automation(metaclass=SingletonMeta):
         return x, y
 
     def mouse_action_with_pos(self, coordinates, offset=True, action="click", times=1, drag_time=None, dx=0, dy=0,
-                              find_type=None, interval=0.5):
+                              find_type=None, interval=0.5, move_back=False):
         """
         在指定坐标上执行点击操作
         参数:
         - coordinates: 坐标位置，用于计算点击位置
         - offset: 是否使用偏移量计算点击位置，默认为True
         - action: 鼠标操作类型，默认为"click"
+        - move_back: 是否在操作后将鼠标移动回原位置，默认为False
         返回值:
         - 总是返回True表示操作执行完毕
         """
         if find_type == 'image_with_multiple_targets' and len(coordinates) > 0:
             for c in coordinates:
-                self.mouse_action_with_pos(c, offset, action, times, dx, dy, find_type="image", interval=1)
+                self.mouse_action_with_pos(c, offset, action, times, dx, dy, find_type="image", interval=1, move_back=move_back)
             return True
 
         if cfg.mouse_action_interval_time and interval == 0.5:
@@ -110,11 +111,11 @@ class Automation(metaclass=SingletonMeta):
         # 根据操作类型执行相应的鼠标操作
         if action in action_map:
             if action == "click":
-                self.mouse_click(x, y, times=times)
+                self.mouse_click(x, y, times=times, move_back=move_back)
             elif action == "drag":
-                self.mouse_drag(x, y, drag_time=drag_time, dx=dx, dy=dy)
+                self.mouse_drag(x, y, drag_time=drag_time, dx=dx, dy=dy, move_back=move_back)
             elif action == "drag_down":
-                self.mouse_drag_down(x, y)
+                self.mouse_drag_down(x, y, move_back=move_back)
             elif action == "scroll":
                 self.mouse_scroll()
             self.last_click_time = time.time()

--- a/module/automation/input.py
+++ b/module/automation/input.py
@@ -14,6 +14,7 @@ class Input(metaclass=SingletonMeta):
     def __init__(self, logger):
         self.is_pause = False
         self.logger = logger
+        # self.is_move_back = False  以后从配置里读取
 
     def set_pause(self):
         self.is_pause = not self.is_pause  # 设置暂停状态
@@ -27,28 +28,74 @@ class Input(metaclass=SingletonMeta):
         while self.is_pause:
             sleep(1)
 
-    def mouse_click(self, x, y, times=1):
+    def mouse_click(self, x, y, times=1, move_back=False):
+        """在指定坐标上执行点击操作
+
+        Args:
+            x (int): x坐标
+            y (int): y坐标
+            times (int): 点击次数
+            move_back (bool): 是否在点击后将鼠标移动回原位置
+        """
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
         msg = f"点击位置:({x},{y})"
         self.logger.DEBUG(msg)
         for i in range(times):
             pyautogui.click(x, y)
-            self.wait_pause()
+            # 多次点击执行很快所以暂停放到循环外
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+        self.wait_pause()
+
         return True
 
-    def mouse_drag_down(self, x, y):
+    def mouse_drag_down(self, x, y, move_back=True):
+        """鼠标从指定位置向下拖动
+
+        Args:
+            x (int): x坐标
+            y (int): y坐标
+            move_back (bool): 是否在拖动后将鼠标移动回原位置
+        """
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
         scale = cfg.set_win_size / 1080
         pyautogui.moveTo(x, y)
         pyautogui.mouseDown()
         pyautogui.dragTo(x, y + int(300 * scale), duration=0.4)
         pyautogui.mouseUp()
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
         msg = f"选择卡包:({x},{y})"
         self.logger.DEBUG(msg)
 
-    def mouse_drag(self, x, y, drag_time=0.1, dx=0, dy=0):
+    def mouse_drag(self, x, y, drag_time=0.1, dx=0, dy=0, move_back=False):
+        """鼠标从指定位置拖动到另一个位置
+        Args:
+            x (int): 起始x坐标
+            y (int): 起始y坐标
+            drag_time (float): 拖动时间
+            dx (int): x方向拖动距离
+            dy (int): y方向拖动距离
+            move_back (bool): 是否在拖动后将鼠标移动回原位置
+        """
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
         pyautogui.moveTo(x, y)
         pyautogui.mouseDown()
         pyautogui.dragTo(x + dx, y + dy, duration=drag_time)
         pyautogui.mouseUp()
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
 
     def mouse_scroll(self, direction=-3):
         if direction <= 0:
@@ -58,18 +105,60 @@ class Input(metaclass=SingletonMeta):
         self.logger.DEBUG(msg)
         pyautogui.scroll(direction)
 
-    def mouse_click_blank(self, coordinate=(1, 1), times=1):
+    def mouse_click_blank(self, coordinate=(1, 1), times=1, move_back=False):
+        """在空白位置点击鼠标
+        Args:
+            coordinate (tuple): 坐标元组 (x, y)
+            times (int): 点击次数
+            move_back (bool): 是否在点击后将鼠标移动回原位置
+        """
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
         msg = "点击（1，1）空白位置"
         self.logger.DEBUG(msg)
         x = coordinate[0] + random.randint(0, 10)
         y = coordinate[1] + random.randint(0, 10)
         for i in range(times):
             pyautogui.click(x, y)
-            self.wait_pause()
+        
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+        self.wait_pause()
         return True
 
-    def mouse_to_blank(self, coordinate=(1, 1)):
+    def mouse_to_blank(self, coordinate=(1, 1), move_back=False):
+        """鼠标移动到空白位置，避免遮挡
+        Args:
+            coordinate (tuple): 坐标元组 (x, y)
+            move_back (bool): 是否在移动后将鼠标移动回原位置
+        """
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
         msg = "鼠标移动到空白，避免遮挡"
         self.logger.DEBUG(msg)
         pyautogui.moveTo(coordinate[0], coordinate[1])
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
         self.wait_pause()
+
+    def mouse_move(self, coordinate=(1, 1)):
+        """鼠标移动到指定坐标
+
+        Args:
+            coordinate (tuple): 坐标元组 (x, y)
+        """
+        pyautogui.moveTo(coordinate[0], coordinate[1])
+        self.wait_pause()
+
+    def get_mouse_position(self):
+        """获取鼠标当前位置
+
+        Returns:
+            tuple: 当前鼠标位置的元组 (x, y)
+        """
+        x, y = pyautogui.position()
+        return (x, y)


### PR DESCRIPTION
## 特性背景
在使用ok-gf2时，发现其实现了对Windows客户端游戏的后台操控能力（可能是基于Win32句柄操作），而当前pyautogui的实现无法支持该特性。同时of-gf2还提供了move_back参数，通过操作完成后将鼠标移回原位置来保证用户操控不受影响。

## 修改内容
本次提交给`automation/input.py`的部分鼠标操作新增move_back参数（默认值为False），其主要特性包括：

非破坏性变更 - 默认行为与原有实现完全一致

新特性 - 操作完成后自动将鼠标归位，减少对用户操作的干扰

## 技术考量
当前暂不实现后台操控功能（因依赖Win32句柄操作，超出pyautogui现有能力范围），后续可根据需求进一步探讨实现方案。

虽然确实有本地多桌面来用，但是考虑到很多用户的计算机水平和操作能力以及花费时间配置的意愿，以及可能需求不需要完全挂在后台，只是暂时移动鼠标播放歌曲或者视频之类的，所以还是加了一下这个特性

---
Introduces a move_back parameter to mouse action methods, allowing the mouse to return to its original position after performing actions such as click, drag, and move. Updates method signatures and internal logic in both automation.py and input.py to support this feature, improving automation flexibility and control.