### PR TITLE
修复编队页面自定义设置无法关闭 & 改进帮助页面markdown渲染

### DIFF
--- a/app/markdown_it_imgdiv.py
+++ b/app/markdown_it_imgdiv.py
@@ -1,0 +1,217 @@
+"""
+A markdown-it-py plugin to wrap images in div containers.
+
+This plugin processes paragraph tokens containing only images and wraps them in div containers,
+similar to the markdown-it-figure plugin for JavaScript markdown-it.
+
+Features:
+- Wraps standalone images in configurable div containers
+- Supports images wrapped in links
+- Adds tabindex for accessibility (optional)
+- Preserves alt text and title attributes
+- Handles multiple images in separate containers
+- Does not interfere with inline images (images mixed with text)
+
+Usage:
+    from markdown_it import MarkdownIt
+    from markdown_it_imgdiv import imgdiv_plugin
+
+    md = MarkdownIt()
+    md.use(imgdiv_plugin, class_name="figure", focusable=True)
+
+    # Example input:
+    # ![Alt text](image.jpg)
+    #
+    # Example output:
+    # <div class="figure"><img src="image.jpg" alt="Alt text" tabindex="0" /></div>
+"""
+
+from typing import TYPE_CHECKING, Optional, Sequence
+from markdown_it import MarkdownIt
+from markdown_it.rules_core import StateCore
+
+if TYPE_CHECKING:
+    from markdown_it.renderer import RendererProtocol
+    from markdown_it.token import Token
+    from markdown_it.utils import EnvType, OptionsDict
+
+
+def imgdiv_plugin(
+    md: MarkdownIt,
+    class_name: str = "image-container",
+    focusable: bool = True,
+    align: Optional[str] = None,
+) -> None:
+    """
+    Plugin to wrap images in div containers.
+
+    Args:
+        md: The MarkdownIt instance
+        class_name: CSS class name for the div wrapper (default: "image-container")
+        focusable: Whether to add tabindex="0" to images for accessibility (default: True)
+    """
+
+    def imgdiv_rule(state: StateCore) -> None:
+        """Core rule to process tokens and wrap images in divs."""
+
+        # Process tokens from start to end, looking for image patterns
+        i = 0
+        while i < len(state.tokens):
+            token = state.tokens[i]
+
+            # Skip if not a paragraph_open token
+            if token.type != "paragraph_open":
+                i += 1
+                continue
+
+            # Check if we have the pattern: paragraph_open -> inline -> paragraph_close
+            if (
+                i + 2 >= len(state.tokens)
+                or state.tokens[i + 1].type != "inline"
+                or state.tokens[i + 2].type != "paragraph_close"
+            ):
+                i += 1
+                continue
+
+            inline_token = state.tokens[i + 1]
+
+            # Check if inline token contains only image(s) or image(s) wrapped in link(s)
+            if not _is_image_only_content(inline_token):
+                i += 1
+                continue
+
+            # We have a paragraph containing only image(s)
+            # Convert paragraph tokens to div tokens
+            paragraph_open = state.tokens[i]
+            paragraph_close = state.tokens[i + 2]
+
+            # Transform paragraph_open to div_open
+            paragraph_open.type = "div_open"
+            paragraph_open.tag = "div"
+            paragraph_open.attrSet("class", class_name)
+            if align:
+                paragraph_open.attrSet("align", align)
+
+
+            # Transform paragraph_close to div_close
+            paragraph_close.type = "div_close"
+            paragraph_close.tag = "div"
+
+            # Process images within the inline token
+            if inline_token.children:
+                _process_images(inline_token.children, focusable)
+
+            # Move to next token after the processed group
+            i += 3
+
+    def _is_image_only_content(inline_token: "Token") -> bool:
+        """Check if inline token contains only images or images wrapped in links."""
+        if not inline_token.children:
+            return False
+
+        children = inline_token.children
+
+        # Single image
+        if len(children) == 1 and children[0].type == "image":
+            return True
+
+        # Image wrapped in link: link_open -> image -> link_close
+        if (
+            len(children) == 3
+            and children[0].type == "link_open"
+            and children[1].type == "image"
+            and children[2].type == "link_close"
+        ):
+            return True
+
+        # Multiple images (potentially mixed with links)
+        i = 0
+        while i < len(children):
+            child = children[i]
+
+            if child.type == "image":
+                # Standalone image
+                i += 1
+            elif (
+                child.type == "link_open"
+                and i + 2 < len(children)
+                and children[i + 1].type == "image"
+                and children[i + 2].type == "link_close"
+            ):
+                # Image wrapped in link
+                i += 3
+            else:
+                # Non-image content found
+                return False
+
+        return True
+
+    def _process_images(children: Sequence["Token"], focusable: bool) -> None:
+        """Process images within the children tokens."""
+        for child in children:
+            if child.type == "image":
+                _enhance_image(child, focusable)
+
+    def _enhance_image(image_token: "Token", focusable: bool) -> None:
+        """Enhance a single image token."""
+        # Add focusable attribute if enabled
+        if focusable:
+            image_token.attrSet("tabindex", "0")
+
+    # Register the core rule
+    md.core.ruler.before("linkify", "imgdiv", imgdiv_rule)
+
+
+# Use default renderers for div tokens
+def render_div_open(
+    self: "RendererProtocol",
+    tokens: Sequence["Token"],
+    idx: int,
+    options: "OptionsDict",
+    env: "EnvType",
+) -> str:
+    """Render opening div tag using default renderer."""
+    return self.renderToken(tokens, idx, options, env)  # type: ignore[attr-defined,no-any-return]
+
+
+def render_div_close(
+    self: "RendererProtocol",
+    tokens: Sequence["Token"],
+    idx: int,
+    options: "OptionsDict",
+    env: "EnvType",
+) -> str:
+    """Render closing div tag using default renderer."""
+    return self.renderToken(tokens, idx, options, env)  # type: ignore[attr-defined,no-any-return]
+
+
+# Example usage and testing
+if __name__ == "__main__":
+    from markdown_it import MarkdownIt
+
+    # Create markdown-it instance with the plugin
+    md = MarkdownIt("commonmark", {"breaks": True, "linkify": True})
+    md.use(imgdiv_plugin, class_name="figure", focusable=True)
+
+    # Add custom renderers
+    md.add_render_rule("div_open", render_div_open)
+    md.add_render_rule("div_close", render_div_close)
+
+    # Test cases
+    test_cases = [
+        "![Alt text](image.jpg)",
+        "[![Alt text](image.jpg)](link.html)",
+        "![Alt text](image.jpg 'Title text')",
+        "Some text ![image](img.jpg) more text",
+        "![Image 1](img1.jpg)\n\n![Image 2](img2.jpg)",
+        "![](image.jpg)\n\nSome paragraph text.",
+    ]
+
+    print("Testing markdown-it-imgdiv plugin:")
+    print("=" * 50)
+
+    for i, test in enumerate(test_cases, 1):
+        print(f"\nTest {i}: {test}")
+        print("-" * 30)
+        result = md.render(test)
+        print(result)

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -74,8 +74,6 @@ class MainWindow(FramelessWindow):
             self.help_interface = MarkdownViewer("./assets/doc/zh/How_to_use.md")
         else:
             self.help_interface = MarkdownViewer("./assets/doc/en/How_to_use_EN.md")
-        # 手动处理链接点击以处理md文件
-        self.help_interface.linkClicked.connect(self.handle_link_click)
 
         self.setting_interface = SettingInterface(self)
         #self.team_setting = TeamSettingCard(self)

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -1,9 +1,11 @@
-from PyQt5.QtCore import Qt, QFile, QTextStream, pyqtSignal, QEvent
+from PyQt5.QtCore import Qt, QFile, QTextStream, pyqtSignal, QEvent, QUrl
 from PyQt5.QtWidgets import QVBoxLayout, QWidget, QFrame, QHBoxLayout, QTextBrowser, QVBoxLayout
-from PyQt5.QtGui import QFont
+from PyQt5.QtGui import QFont, QDesktopServices
 
-import markdown
-import re
+import os
+from markdown_it import MarkdownIt
+from mdit_py_plugins.anchors import anchors_plugin
+from .markdown_it_imgdiv import imgdiv_plugin, render_div_open, render_div_close
 
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import SegmentedWidget, ScrollArea, TransparentToolButton
@@ -299,129 +301,113 @@ class PageMirror(PageCard):
         mediator.refresh_teams_order.connect(self.refresh)
 
 
-class MarkdownViewer(QTextBrowser):
+def transform_image_url(self, tokens, idx, options, env):
+    token = tokens[idx]
+    src = token.attrs["src"]
+    if isinstance(src, str):
+        url = QUrl(src)
+        if url.path().startswith("/"):
+            new_src = "." + url.path()
+            tokens[idx].attrSet("src", new_src)
 
-    # 自定义信号，当链接被点击时发出
-    linkClicked = pyqtSignal(str)  # 参数为链接URL字符串
-    
+    return self.image(tokens, idx, options, env)
 
-    def __init__(self, file_path=None):
+class MarkdownViewer(QWidget):
+    def __init__(self, file_path: str):
         super().__init__()
-        
-        # 设置文本浏览器属性
-        self.setOpenExternalLinks(False)
-        self.setOpenLinks(False)
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
 
-        self.setContextMenuPolicy(Qt.NoContextMenu) # 禁用鼠标右键
+        self.text_browser = QTextBrowser()
+        self.text_browser.setOpenExternalLinks(False)
+        self.text_browser.anchorClicked.connect(self.handle_link_clicked)
 
-        font = QFont("Microsoft YaHei", 10)
-        self.setFont(font)
+        css_path = "assets/styles/github-markdown-light.css"
+        with open(css_path, "r", encoding="utf-8") as css_file:
+            css_content = css_file.read()
+            self.text_browser.setStyleSheet(css_content)
 
-        self.viewport().setMouseTracking(True)
+        self.md = (
+            MarkdownIt("commonmark", {"html": True})
+            .enable("linkify")
+            .enable("table")
+            .enable("strikethrough")
+            .use(
+                anchors_plugin,
+                max_level=4,
+                slug_func=lambda s: s.lower().replace(" ", "-"),
+            )
+        )
+        self.md.add_render_rule("image", transform_image_url)
+        self.md.use(imgdiv_plugin, class_name="figure", focusable=False, align="center")
 
-        self.css_style = """
-        QTextBrowser { color: #1F2328; font-family: "Microsoft YaHei", sans-serif; line-height: 1.2}
-        QScrollBar::handle:vertical { border-radius: 60px; }
-        body { color: #1F2328; font-family: "Microsoft YaHei", sans-serif; margin: 20px; line-height: 1.2}
-        img { max-width: 50%; }
-        pre, code {
-            font-family: Consolas, "Courier New", monospace;
-            font-size: large;
-            line-height: 1;
-            color: #24292e;
-            background-color: #f6f8fa;
-            overflow: auto;
-        }
-        code { font-size: smaller ; line-height: 1.5;}
-        a { color: #0969DA;}
-        hr { background-color: #D1D9E0; height: 4px; border: none; }
-        table { border-collapse: collapse; width: 100%; margin: 10px 0; }
-        th, td { border: 1px solid #ddd; padding: 8px; }
+        self.md.add_render_rule("div_open", render_div_open)
+        self.md.add_render_rule("div_close", render_div_close)
+
+        self.html = """
+        <html>
+            <body>
+                <h1>帮助页面加载失败！</h1>
+            </body>
+        </html>
         """
-        self.setStyleSheet(self.css_style)
 
-        if file_path:
-            self.load_markdown(file_path)
-
-    def mouseReleaseEvent(self, event):
-        """处理鼠标释放事件，捕获链接点击"""
-        # 只处理左键点击
-        if event.button() == Qt.LeftButton:
-            anchor = self.anchorAt(event.pos())
-            if anchor:
-                # 检查链接类型
-                if anchor.endswith(".md"):
-                    self.linkClicked.emit(anchor)
-                    return  # 拦截事件，阻止默认行为
-        
-        super().mouseReleaseEvent(event)
-
-    def load_markdown(self, file_path):
-        try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                md_content = f.read()
-
-            def convert_strikethrough(text):
-                return re.sub(r'~~(.*?)~~', r'<del>\1</del>', text)
-
-            md_content = convert_strikethrough(md_content)
-
-            def preprocess_divs(text):
-                def convert_div(match):
-                    inner = match.group(1)
-                    # 单独转换div内部内容
-                    return f'<div align="center">\n{markdown.markdown(inner)}\n</div>'
-                
-                return re.sub(r'<div[^>]*>(.*?)</div>', convert_div, text, flags=re.DOTALL)
-
-            md_content = preprocess_divs(md_content)
-
-            extensions = [
-                "extra",
-                "tables",
-                "fenced_code",
-                "toc",
-                "sane_lists",
-                "nl2br",
-                "admonition",
-            ]
-
-            html_content = markdown.markdown(
-                md_content,
-                extensions=extensions,
-                output_format="html5"
+        layout.addWidget(self.text_browser)
+        self.help_path = file_path
+        self.reset_viewer()
+    
+    def reset_viewer(self):
+        if os.path.exists(self.help_path):
+            self.load_markdown(self.help_path)
+            self.text_browser.setHtml(self.html)
+        else:
+            self.text_browser.setPlainText(
+                f"错误: 无法加载文件 {self.help_path}，请检查文件路径是否正确。"
             )
 
-            
-            html = f"""<!DOCTYPE html>
-            <html>
-            <head>
-                <meta charset="UTF-8">
-                <title>AhabAssistantLimbusCompany</title>
-                <style>
-                    {self.css_style}
-                </style>
-            </head>
-            <body>
-            <div id="content">
-            {html_content}
-            </div>
-            </body>
-            </html>"""
+    def handle_link_clicked(self, url: QUrl):
+        """
+        Decides how to handle a clicked link in the QTextBrowser.
+        """
+        if url.scheme() in ["http", "https"]:
+            # 用系统默认浏览器打开外部链接
+            QDesktopServices.openUrl(url)
+        elif url.scheme() != "":
+            # 其他链接，不处理
+            pass
+        else:
+            # 本地文件
+            file_path = url.path()
+            if file_path.startswith("/"):
+                # 处理以项目根目录为base的路径
+                file_path = file_path[1:]
 
-            # with open("Generated.html", 'w', encoding='utf-8') as f:
-            #     f.write(html)
-            
-            
+            if os.path.exists(file_path) and file_path.endswith(".md"):
+                # 如果是本地文件链接，尝试加载 Markdown 文件
+                self.load_markdown(file_path)
+                self.text_browser.setHtml(self.html)
 
-            self.setHtml(html)
+                if url.hasFragment():
+                    # 如果链接有锚点，滚动到对应的锚点
+                    self.text_browser.scrollToAnchor(url.fragment())
+                return
 
+        self.text_browser.setHtml(self.html)
+
+    def load_markdown(self, file_path: str):
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                markdown_text = f.read()
+
+                html_body = self.md.render(markdown_text)
+
+                # 添加 HTML 头部
+                self.html = f"""
+                <html>
+                <body>
+                    {html_body}
+                </body>
+                </html>
+                """
         except Exception as e:
-            # 显示错误信息
-            error_html = f"""
-            <html><body style="color: red; font-family: Arial; padding: 20px;">
-            <h2>错误: 无法加载文件</h2>
-            <pre>{str(e)}</pre>
-            </body></html>
-            """
-            self.setHtml(error_html)
+            self.text_browser.setPlainText(f"错误: 无法加载文件\n{str(e)}")

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -321,6 +321,7 @@ class MarkdownViewer(QWidget):
         self.text_browser = QTextBrowser()
         self.text_browser.setOpenExternalLinks(False)
         self.text_browser.anchorClicked.connect(self.handle_link_clicked)
+        self.text_browser.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu) # 禁用右键菜单
 
         css_path = "assets/styles/github-markdown-light.css"
         with open(css_path, "r", encoding="utf-8") as css_file:

--- a/app/team_setting_card.py
+++ b/app/team_setting_card.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QFrame, QVBoxLayout, QWidget, QHBoxLayout, QSizePolicy, QGridLayout
-from qfluentwidgets import FluentIcon as FIF, ExpandSettingCard
+from qfluentwidgets import FluentIcon as FIF, SimpleExpandGroupSettingCard
 from qfluentwidgets import ScrollArea, PrimaryPushButton, PushButton
 
 from app import *
@@ -38,7 +38,7 @@ class TeamSettingCard(QFrame):
         self.page_widget = QWidget()
         self.scroll_general.setWidget(self.page_widget)
 
-        self.layout = QVBoxLayout(self.page_widget)
+        self.layout_ = QVBoxLayout(self.page_widget)
 
         self.main_layout.addWidget(self.scroll_general)
 
@@ -53,7 +53,7 @@ class TeamSettingCard(QFrame):
         self.gift_system_list_1 = QHBoxLayout()
         self.gift_system_list_2 = QHBoxLayout()
 
-        self.custom_layout = ExpandSettingCard(icon=FIF.EDIT, title="自定义设置", parent=self)
+        self.custom_layout = SimpleExpandGroupSettingCard(icon=FIF.EDIT, title="自定义设置", parent=self)
 
         self.setting_layout = QHBoxLayout()
 
@@ -135,12 +135,12 @@ class TeamSettingCard(QFrame):
         self.setting_layout.addWidget(self.cancel_button)
         self.setting_layout.addWidget(self.confirm_button)
 
-        self.layout.addWidget(self.combobox_layout)
-        self.layout.addLayout(self.select_sinner_layout_1)
-        self.layout.addLayout(self.select_sinner_layout_2)
-        self.layout.addWidget(self.gift_system_layout)
-        self.layout.addWidget(self.custom_layout)
-        self.layout.addLayout(self.setting_layout)
+        self.layout_.addWidget(self.combobox_layout)
+        self.layout_.addLayout(self.select_sinner_layout_1)
+        self.layout_.addLayout(self.select_sinner_layout_2)
+        self.layout_.addWidget(self.gift_system_layout)
+        self.layout_.addWidget(self.custom_layout)
+        self.layout_.addLayout(self.setting_layout)
 
         self.custom_layout.viewLayout.addWidget(self.customize_settings_module)
 

--- a/assets/doc/en/FAQ_EN.md
+++ b/assets/doc/en/FAQ_EN.md
@@ -40,19 +40,19 @@ Ways to switch input methods:
 
 Q: After starting, can I not move the keyboard and mouse or switch to the background?
 
-A: Yes, if you need to run it in the background, please try [Remote Local Multi - User Desktop](/README.md#background - running).
+A: Yes, if you need to run it in the background, please try [Remote Local Multi - User Desktop](/assets/doc/en/README_EN.md#running-in-the-background).
 
 ---
 
 Q: I'm stuck in XXX / XXX seems to be unrecognizable all the time.
 
-A: Check if your computer has enabled night mode. For more details, refer to [this](<url id="cukbv53djm8j2js93phg" type="url" status="parsed" title="KIYI671/AhabAssistantLimbusCompany" wc="741">https://github.com/KIYI671/AhabAssistantLimbusCompany/issues/70)</url>.
+A: Check if your computer has enabled night mode. For more details, refer to [this](https://github.com/KIYI671/AhabAssistantLimbusCompany/issues/70).
 
 ---
 
 Q: I encountered the XXX theme pack, which led to the death of all members. Can I set it not to enter?
 
-A: Yes, you can set it not to enter. Please try [Setting Theme Pack Weight](/README.md#theme - pack - weight - setting) on your own.
+A: Yes, you can set it not to enter. Please try [Setting Theme Pack Weight](/README_EN.md#theme-package-weight-setting) on your own.
 
 ---
 

--- a/assets/doc/en/How_to_use_EN.md
+++ b/assets/doc/en/How_to_use_EN.md
@@ -2,13 +2,13 @@
 
 # How To Use
 
-[简体中文](./assets/doc/zh/How_to_use.md) | **English**
+[简体中文](/assets/doc/zh/How_to_use.md) | **English**
 
 </div>
 
 ---
 
-![image](./assets/doc/image/main_page.png)
+![image](/assets/doc/image/main_page.png)
 
 #### ① Lets you set the window resolution size
 #### ② Used to select the in-game language (i.e. it needs to be adapted to the in-game language)
@@ -22,19 +22,19 @@
 
 ---
 
-![image](./assets/doc/image/page_1.png)
+![image](/assets/doc/image/page_1.png)
 
 ---
 
-![image](./assets/doc/image/page_2.png)
+![image](/assets/doc/image/page_2.png)
 
 ---
 
-![image](./assets/doc/image/page_3.png)
+![image](/assets/doc/image/page_3.png)
 
 ---
 
-![image](./assets/doc/image/page_4.png)
+![image](/assets/doc/image/page_4.png)
 
 #### ① Enable/Deactivate after clicking This team is used for the Mirror Prison
 #### ② Used to showcase the rotation order of the enabled teams
@@ -44,7 +44,7 @@
 
 ---
 
-![image](./assets/doc/image/page_5.png)
+![image](/assets/doc/image/page_5.png)
 
 #### ① Select the system used by your team
 #### ② Select the team number to be used by the team

--- a/assets/doc/zh/How_to_use.md
+++ b/assets/doc/zh/How_to_use.md
@@ -2,13 +2,13 @@
 
 # 用法详解
 
-**简体中文** | [English](./assets/doc/en/How_to_use_EN.md)
+**简体中文** | [English](/assets/doc/en/How_to_use_EN.md)
 
 </div>
 
 ---
 
-![image](./assets/doc/image/main_page.png)
+![image](/assets/doc/image/main_page.png)
 
 #### ① 用于设置窗口分辨率大小
 #### ② 用于选择游戏内语言（即需要与游戏内语言相适配）
@@ -22,19 +22,19 @@
 
 ---
 
-![image](./assets/doc/image/page_1.png)
+![image](/assets/doc/image/page_1.png)
 
 ---
 
-![image](./assets/doc/image/page_2.png)
+![image](/assets/doc/image/page_2.png)
 
 ---
 
-![image](./assets/doc/image/page_3.png)
+![image](/assets/doc/image/page_3.png)
 
 ---
 
-![image](./assets/doc/image/page_4.png)
+![image](/assets/doc/image/page_4.png)
 
 #### ① 点击后启用/取消启用 此队伍用于镜牢
 #### ② 用于展示已启用队伍的轮换排序
@@ -44,7 +44,7 @@
 
 ---
 
-![image](./assets/doc/image/page_5.png)
+![image](/assets/doc/image/page_5.png)
 
 #### ① 选择本配队使用的体系
 #### ② 选择本配队使用的队伍序号

--- a/assets/styles/github-markdown-light.css
+++ b/assets/styles/github-markdown-light.css
@@ -1,0 +1,408 @@
+/* light - Qt-compatible styles only */
+QTextBrowser {
+  color: #1f2328;
+  background-color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, "Microsoft YaHei", sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+body {
+  color: #1f2328;
+  background-color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, "Microsoft YaHei", sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+a {
+  background-color: transparent;
+  color: #0969da;
+  text-decoration: none;
+}
+
+b,
+strong {
+  font-weight: 600;
+}
+
+dfn {
+  font-style: italic;
+}
+
+h1 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  padding-bottom: 5px;
+  font-size: 32px;
+  border-bottom: 1px solid #d1d9e0;
+}
+
+h2 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  padding-bottom: 5px;
+  font-size: 24px;
+  border-bottom: 1px solid #d1d9e0;
+}
+
+h3 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  font-size: 20px;
+}
+
+h4 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  font-size: 16px;
+}
+
+h5 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #59636e;
+}
+
+mark {
+  background-color: #fff8c5;
+  color: #1f2328;
+}
+
+small {
+  font-size: 14px;
+}
+
+sub {
+  vertical-align: sub;
+  font-size: 12px;
+}
+
+sup {
+  vertical-align: super;
+  font-size: 12px;
+}
+
+p {
+  margin-top: 0px;
+  margin-bottom: 16px;
+}
+
+blockquote {
+  margin-top: 0px;
+  margin-bottom: 16px;
+  padding-left: 16px;
+  color: #59636e;
+  border-left: 4px solid #d1d9e0;
+}
+
+ul,
+ol {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  padding-left: 32px;
+}
+
+ul ul ol,
+ul ol ol,
+ol ul ol,
+ol ol ol {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+li {
+  margin-top: 4px;
+}
+
+dd {
+  margin-left: 0px;
+}
+
+tt,
+code,
+samp {
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+}
+
+pre {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 12px;
+  white-space: pre;
+}
+
+hr {
+  background-color: #d1d9e0;
+  border: 0px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+kbd {
+  padding: 4px;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  font-size: 11px;
+  line-height: 10px;
+  color: #1f2328;
+  vertical-align: middle;
+  background-color: #f6f8fa;
+  border: 1px solid #d1d9e0;
+  border-bottom-color: #d1d9e0;
+}
+
+table {
+  border-collapse: collapse;
+  margin-bottom: 16px;
+}
+
+td,
+th {
+  padding: 6px 13px;
+  border: 1px solid #d1d9e0;
+}
+
+table tr {
+  background-color: #ffffff;
+  border-top: 1px solid #d1d9e0;
+}
+
+table th {
+  font-weight: 600;
+}
+
+dl {
+  padding: 0px;
+}
+
+dl dt {
+  padding: 0px;
+  margin-top: 16px;
+  font-size: 16px;
+  font-style: italic;
+  font-weight: 600;
+}
+
+dl dd {
+  padding-left: 16px;
+  margin-bottom: 16px;
+}
+
+code,
+tt {
+  padding: 3px 6px;
+  margin: 0px;
+  font-size: 14px;
+  white-space: pre;
+  background-color: #f0f0f0;
+}
+
+pre code {
+  font-size: 14px;
+  padding: 0px;
+  margin: 0px;
+  white-space: pre;
+  background-color: transparent;
+  border: 0px;
+}
+
+pre {
+  padding: 16px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: #1f2328;
+  background-color: #f6f8fa;
+}
+
+/* Task list items - removed unsupported attribute selector */
+
+/* Markdown alerts */
+div.markdown-alert {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  margin-bottom: 16px;
+  color: inherit;
+  border-left: 4px solid #d1d9e0;
+}
+
+div.markdown-alert-note {
+  border-left-color: #0969da;
+}
+
+div.markdown-alert-important {
+  border-left-color: #8250df;
+}
+
+div.markdown-alert-warning {
+  border-left-color: #9a6700;
+}
+
+div.markdown-alert-tip {
+  border-left-color: #1a7f37;
+}
+
+div.markdown-alert-caution {
+  border-left-color: #cf222e;
+}
+
+/* Syntax highlighting colors (simplified for Qt compatibility) */
+span.pl-c {
+  color: #59636e;
+}
+
+span.pl-c1 {
+  color: #0550ae;
+}
+
+span.pl-v {
+  color: #0550ae;
+}
+
+span.pl-e {
+  color: #6639ba;
+}
+
+span.pl-en {
+  color: #6639ba;
+}
+
+span.pl-smi {
+  color: #1f2328;
+}
+
+span.pl-s1 {
+  color: #1f2328;
+}
+
+span.pl-ent {
+  color: #0550ae;
+}
+
+span.pl-k {
+  color: #cf222e;
+}
+
+span.pl-s {
+  color: #0a3069;
+}
+
+span.pl-pds {
+  color: #0a3069;
+}
+
+span.pl-pse {
+  color: #0a3069;
+}
+
+span.pl-sr {
+  color: #0a3069;
+}
+
+span.pl-cce {
+  color: #0a3069;
+}
+
+span.pl-sre {
+  color: #0a3069;
+}
+
+span.pl-sra {
+  color: #0a3069;
+}
+
+span.pl-smw {
+  color: #953800;
+}
+
+span.pl-bu {
+  color: #82071e;
+}
+
+span.pl-ii {
+  color: #f6f8fa;
+  background-color: #82071e;
+}
+
+span.pl-c2 {
+  color: #f6f8fa;
+  background-color: #cf222e;
+}
+
+span.pl-ml {
+  color: #3b2300;
+}
+
+span.pl-mh {
+  font-weight: bold;
+  color: #0550ae;
+}
+
+span.pl-ms {
+  font-weight: bold;
+  color: #0550ae;
+}
+
+span.pl-mi {
+  font-style: italic;
+  color: #1f2328;
+}
+
+span.pl-mb {
+  font-weight: bold;
+  color: #1f2328;
+}
+
+span.pl-md {
+  color: #82071e;
+  background-color: #ffebe9;
+}
+
+span.pl-mi1 {
+  color: #116329;
+  background-color: #dafbe1;
+}
+
+span.pl-mc {
+  color: #953800;
+  background-color: #ffd8b5;
+}
+
+span.pl-mi2 {
+  color: #d1d9e0;
+  background-color: #0550ae;
+}
+
+span.pl-mdr {
+  font-weight: bold;
+  color: #8250df;
+}
+
+span.pl-ba {
+  color: #59636e;
+}
+
+span.pl-sg {
+  color: #818b98;
+}
+
+span.pl-corl {
+  text-decoration: underline;
+  color: #0a3069;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ PyGetWindow==0.0.9
 PyMsgBox==1.0.9
 pynput==1.7.7
 pyperclip==1.9.0
-PyQt-Fluent-Widgets==1.7.3
+PyQt-Fluent-Widgets==1.8.4
 PyQt5==5.15.11
 PyQt5-Frameless-Window==0.4.3
 PyQt5-Qt5==5.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,8 @@ tzlocal==5.2
 urllib3==2.2.3
 wrapt==1.17.0
 pyuac~=0.0.3
-Markdown~=3.7
+markdown-it-py~=3.0.0
+mdit-py-plugins~=0.4.2
 packaging~=24.2
 playsound3~=2.5.2
 cpufeature~=0.2.1


### PR DESCRIPTION
* 自定义设置是PyQt-Fluent-Widgets的问题，已经发patch给上游了。上游发布新版本前可以先切换到没bug的组件
* markdown渲染的改进：
  * 改用markdown-it-py以更好地处理含html标签的md文本
  * 实现markdown-it插件以自动处理`/`开头的图片链接并将`<img>`包在`<div>`中
    * 把`/asset/xxx`改成`./asset/xxx`是可以解决程序里的显示问题，但会导致在本地/github直接打开md文件时不能显示图片
    * 把图片包到`<div>`里以实现居中效果
  * 处理anchor以支持标题链接跳转
    * 使用markdown-it为标题生成anchor
    * 正确处理含有anchor的链接跳转（如`/README.md#后台运行`）