### PR TITLE
fix: 防止cdk不经过处理直接出现在日志导致的泄露

### DIFF
--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -10,6 +10,7 @@ from app.card.messagebox_custom import MessageBoxEdit
 from app.language_manager import LanguageManager
 from module.update.check_update import check_update
 
+from utils.utils import encrypt_string, decrypt_string
 
 class CheckBoxWithButton(QFrame):
     def __init__(self, check_box_name, check_box_title, check_box_icon: Union[str, QIcon, FluentIconBase, None],
@@ -387,7 +388,7 @@ class BasePrimaryPushSettingCard(PrimaryPushSettingCard):
 
 class PushSettingCardMirrorchyan(SettingCard):
     def __init__(self, text, icon: Union[str, QIcon, FluentIconBase], title, update_callback, config_name, parent=None):
-        self.config_value = str(cfg.get_value(config_name))
+        self.config_value = decrypt_string(str(cfg.get_value(config_name)))
         self.update_callback = update_callback
         super().__init__(icon, title, "", parent)
 
@@ -409,7 +410,8 @@ class PushSettingCardMirrorchyan(SettingCard):
     def __onclicked(self):
         message_box = MessageBoxEdit(self.tr(self.title), self.config_value, self.window())
         if message_box.exec():
-            cfg.set_value(self.config_name, message_box.getText())
+            base64_cdk = encrypt_string(message_box.getText())
+            cfg.set_value(self.config_name, base64_cdk)
             self.contentLabel.setText(message_box.getText())
             self.config_value = message_box.getText()
             parent = self._find_parent(self)

--- a/app/card/messagebox_custom.py
+++ b/app/card/messagebox_custom.py
@@ -120,9 +120,13 @@ class MessageBoxEdit(MessageBox):
 
         self.lineEdit = LineEdit(self)
         self.lineEdit.setText(self.content)
+        self.lineEdit.returnPressed.connect(self.yesButton.click)
+
         self.textLayout.addWidget(self.lineEdit, 0, Qt.AlignTop)
 
         self.buttonGroup.setMinimumWidth(400)
+
+        self.lineEdit.setFocus()
 
     def getText(self):
         return self.lineEdit.text()

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -475,10 +475,12 @@ class PageMirror(PageCard):
     def refresh_team_setting_card(self):
         for i in range(1, 21):
             if cfg.get_value(f"team{i}_setting") is None and cfg.get_value(f"team{i + 1}_setting") is not None:
-                cfg.set_value(f"team{i}_setting", cfg.get_value(f"team{i + 1}_setting"))
-                cfg.del_key(f"team{i + 1}_setting")
-                cfg.set_value(f"team{i}_remark_name", cfg.get_value(f"team{i + 1}_remark_name"))
-                cfg.del_key(f"team{i + 1}_remark_name")
+                cfg.unsaved_set_value(f"team{i}_setting", cfg.get_value(f"team{i + 1}_setting"))
+                cfg.unsaved_del_key(f"team{i + 1}_setting")
+                cfg.unsaved_set_value(f"team{i}_remark_name", cfg.get_value(f"team{i + 1}_remark_name"))
+                cfg.unsaved_del_key(f"team{i + 1}_remark_name")
+        cfg.save_config()
+            
         self.get_setting()
 
     def refresh(self):

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -84,13 +84,7 @@ class Config(metaclass=SingletonMeta):
 
         # 防止 cdk 泄露
         if key == "mirrorchyan_cdk":
-            if isinstance(value, str):
-                if len(value) >= 10:
-                    value = value[:3] + "****" + value[-3:]
-                else:
-                    value = value[:2] + "****"
-            else:
-                value = "****"
+            value = "已加密"
 
         log.DEBUG(f"{key} change to: {value}") # 增加设置修改的信息
         self.save_config()
@@ -119,13 +113,7 @@ class Config(metaclass=SingletonMeta):
 
         # 防止 cdk 泄露
         if key == "mirrorchyan_cdk":
-            if isinstance(value, str):
-                if len(value) >= 10:
-                    value = value[:3] + "****" + value[-3:]
-                else:
-                    value = value[:2] + "****"
-            else:
-                value = "****"
+            value = "已加密"
 
         log.DEBUG(f"{key} change to: {value}") # 增加设置修改的信息
 

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -82,6 +82,16 @@ class Config(metaclass=SingletonMeta):
         else:
             self.config[key] = value
 
+        # 防止 cdk 泄露
+        if key == "mirrorchyan_cdk":
+            if isinstance(value, str):
+                if len(value) >= 10:
+                    value = value[:3] + "****" + value[-3:]
+                else:
+                    value = value[:2] + "****"
+            else:
+                value = "****"
+
         log.DEBUG(f"{key} change to: {value}") # 增加设置修改的信息
         self.save_config()
 

--- a/module/update/check_update.py
+++ b/module/update/check_update.py
@@ -17,6 +17,8 @@ from module.config import cfg
 from module.decorator.decorator import begin_and_finish_time_log
 from module.logger import log
 
+from utils.utils import decrypt_string
+
 md_renderer = MarkdownIt("gfm-like", {"html": True})
 
 
@@ -208,7 +210,8 @@ class UpdateThread(QThread):
                     self.updateSignal.emit(UpdateStatus.FAILURE)
                     return None
                 # 符合Mirror酱条件
-                response = self.check_update_info_mirrorchyan(cfg.mirrorchyan_cdk)
+                cdk = decrypt_string(cfg.mirrorchyan_cdk)
+                response = self.check_update_info_mirrorchyan(cdk)
                 if response.status_code == 200:
                     mirrorchyan_data = response.json()
                     if mirrorchyan_data["code"] == 0 and mirrorchyan_data["msg"] == "success":

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -106,17 +106,23 @@ def decrypt_string(encrypted_b64: str, entropy: bytes = b'AALC') -> str:
     """使用当前Windows用户凭据解密字符串"""
     if not encrypted_b64:
         return ""
-
-    # 解码Base64
-    encrypted_data = base64.b64decode(encrypted_b64)
     
-    # 解密数据
-    decrypted_data = win32crypt.CryptUnprotectData(
-        encrypted_data,
-        entropy,    # 必须与加密时相同的熵值
-        None,       # 保留
-        None,       # 提示信息
-        0           # 默认标志
-    )
+    if len(encrypted_b64) % 4 != 0:
+        return encrypted_b64
+    try:
+    # 解码Base64
+        encrypted_data = base64.b64decode(encrypted_b64)
+
+    
+        # 解密数据
+        decrypted_data = win32crypt.CryptUnprotectData(
+            encrypted_data,
+            entropy,    # 必须与加密时相同的熵值
+            None,       # 保留
+            None,       # 提示信息
+            0           # 默认标志
+        )
+    except Exception:
+        return encrypted_b64
     # 返回原始字符串
     return decrypted_data[1].decode('utf-8')

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,8 +1,10 @@
+import base64
 from datetime import datetime
 from zoneinfo import ZoneInfo  # Python 3.9+ 内置模块
 
 import cv2
 import numpy as np
+import win32crypt
 
 
 def get_day_of_week():
@@ -76,3 +78,45 @@ def find_skill3(background, known_rgb, threshold=40, min_pixels=10):
         merged.append(np.mean([current] + group, axis=0))
 
     return merged
+
+
+
+def encrypt_string(text: str, entropy: bytes = b'AALC') -> str:
+    """使用当前Windows用户凭据加密字符串"""
+
+    if not text:
+        return ""
+
+    # 转换为字节
+    data = text.encode('utf-8')
+    
+    # 加密数据（只能由同一用户在同一机器上解密）
+    encrypted_data = win32crypt.CryptProtectData(
+        data,
+        None,       # 描述字符串（可选）
+        entropy,    # 额外熵值（增强安全性）
+        None,       # 保留
+        None,       # 提示信息
+        0           # 默认标志：CRYPTPROTECT_UI_FORBIDDEN
+    )
+    # 返回Base64编码的加密结果
+    return base64.b64encode(encrypted_data).decode('utf-8')
+
+def decrypt_string(encrypted_b64: str, entropy: bytes = b'AALC') -> str:
+    """使用当前Windows用户凭据解密字符串"""
+    if not encrypted_b64:
+        return ""
+
+    # 解码Base64
+    encrypted_data = base64.b64decode(encrypted_b64)
+    
+    # 解密数据
+    decrypted_data = win32crypt.CryptUnprotectData(
+        encrypted_data,
+        entropy,    # 必须与加密时相同的熵值
+        None,       # 保留
+        None,       # 提示信息
+        0           # 默认标志
+    )
+    # 返回原始字符串
+    return decrypted_data[1].decode('utf-8')


### PR DESCRIPTION
## perf: 让`MessageBoxEdit`操作更方便
- 将文本框设置为焦点方便直接编辑
- 在文本框内按下回车会按下`yesbutton`

## perf: 提高删除镜牢编队的速度
- 通过减少io次数加快速度 (原来最多可以进行76次io操作)

## fix: 使用加密和解密函数保护cdk信息，防止泄露
- 通过 Windows Data Protection API (DPAPI) 加密和解密cdk, 并经过 base64 后保存