### PR TITLE
Fix:临时禁用清除缓存功能

### DIFF
--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -62,7 +62,7 @@ def back_init_menu():
         if clear_all_caches := auto.find_element("base/clear_all_caches_assets.png", model="clam"):
             if auto.click_element("base/update_confirm_assets.png"):
                 continue
-            auto.mouse_click(clear_all_caches[0], clear_all_caches[1] - 100)
+            # auto.mouse_click(clear_all_caches[0], clear_all_caches[1] - 100) 临时禁用清除缓存功能
             continue
 
         auto.mouse_click_blank()

--- a/tasks/base/retry.py
+++ b/tasks/base/retry.py
@@ -71,7 +71,7 @@ def retry():
             auto.click_element("base/retry.png", threshold=0.9)
             continue
         if clear_all_caches := auto.find_element("base/clear_all_caches_assets.png", model="clam"):
-            auto.mouse_click(clear_all_caches[0], clear_all_caches[1] - 100)
+            # auto.mouse_click(clear_all_caches[0], clear_all_caches[1] - 100)
             continue
         break
 


### PR DESCRIPTION
由于清除缓存之后会重下多大十几G游戏数据，紧急禁用该功能