### PR TITLE
Feat:添加了跳过活动卡包的功能

### DIFF
--- a/app/page_card.py
+++ b/app/page_card.py
@@ -388,6 +388,11 @@ class PageMirror(PageCard):
             QT_TRANSLATE_NOOP("BaseCheckBox", "第五层选择（最左边）活动卡包"),
             center=False
         )
+        self.skip_event_pack = BaseCheckBox(
+            "skip_event_pack", None,
+            QT_TRANSLATE_NOOP("BaseCheckBox", "第五层跳过（最左边）活动卡包"),
+            center=False
+        )
         self.re_claim_rewards = BaseCheckBox(
             "re_claim_rewards", None,
             QT_TRANSLATE_NOOP("BaseCheckBox", "再次领取奖励"),
@@ -407,6 +412,8 @@ class PageMirror(PageCard):
         self.vbox_advanced.addWidget(self.save_rewards)
         self.vbox_advanced.addWidget(self.hard_mirror_single_bonuses)
         self.vbox_advanced.addWidget(self.select_event_pack)
+        self.vbox_advanced.addWidget(self.skip_event_pack)
+        self.vbox_advanced.addWidget(self.re_claim_rewards)
 
         self.card_layout.insertWidget(self.card_layout.count() - 1, self.mirror_count)
 
@@ -532,6 +539,8 @@ class PageMirror(PageCard):
         self.save_rewards.retranslateUi()
         self.hard_mirror_single_bonuses.retranslateUi()
         self.select_event_pack.retranslateUi()
+        self.skip_event_pack.retranslateUi()
+        self.re_claim_rewards.retranslateUi()
         for child in self.findChildren(MirrorTeamCombination):
             child.retranslateUi()
 

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -81,6 +81,7 @@ infinite_dungeons: False # 无限刷牢
 save_rewards: False # 保存奖励不领
 hard_mirror_single_bonuses: False # 困难镜牢使用单次加成
 select_event_pack: False # 第五层选择（最左边）活动卡包
+skip_event_pack: False # 第五层跳过（最左边）活动卡包
 re_claim_rewards: False # 再次执行领取奖励任务
 teams_be_select_num: 0 # 被选中的队伍数量
 teams_be_select: [ False ] # 被选中的队伍

--- a/tasks/mirror/select_theme_pack.py
+++ b/tasks/mirror/select_theme_pack.py
@@ -78,6 +78,7 @@ def select_theme_pack(hard_switch=False, floor=None):
             if all_theme_pack := auto.find_element("mirror/theme_pack/theme_pack_features.png",
                                                    find_type='image_with_multiple_targets'):
                 if floor == 4 and cfg.skip_event_pack:
+                    all_theme_pack.sort(key=lambda pos: (pos[0], pos[1]))
                     all_theme_pack.pop(0) # 删除最左边的卡包
                 for pack in all_theme_pack:
                     top_left = (

--- a/tasks/mirror/select_theme_pack.py
+++ b/tasks/mirror/select_theme_pack.py
@@ -77,6 +77,8 @@ def select_theme_pack(hard_switch=False, floor=None):
             pack_name = []
             if all_theme_pack := auto.find_element("mirror/theme_pack/theme_pack_features.png",
                                                    find_type='image_with_multiple_targets'):
+                if floor == 4 and cfg.skip_event_pack:
+                    all_theme_pack.pop(0) # 删除最左边的卡包
                 for pack in all_theme_pack:
                     top_left = (
                         max(pack[0] - 210 * scale, 0),


### PR DESCRIPTION
Introduces a new 'skip_event_pack' checkbox in the UI and configuration to allow skipping the leftmost event pack on the fifth floor. Updates logic in select_theme_pack.py to remove the event pack when the option is enabled.

---

通过清除第五层最左边卡包的方法实现了跳过活动卡包，给用户提供活动卡包不好打的情况下不选择的选项

修复了 https://github.com/KIYI671/AhabAssistantLimbusCompany/commit/29493b6f1aa5338133cd95f38e727402f318860e 再次领取奖励未添加界面的问题