### PR TITLE
feat

### DIFF
--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -304,7 +304,7 @@ class FarmingInterfaceLeft(QWidget):
             if child.objectName() == "link_start":
                 continue
             # 检查是否为目标控件类型
-            if isinstance(child, (BaseButton, CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
+            if isinstance(child, (ToSettingButton, CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
                 child.setEnabled(False)
             else:
                 # 递归处理子部件的子部件（如布局中的嵌套控件）
@@ -318,7 +318,7 @@ class FarmingInterfaceLeft(QWidget):
             if child.objectName() == "set_windows":
                 continue
             # 检查是否为目标控件类型
-            if isinstance(child, (BaseButton, CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
+            if isinstance(child, (ToSettingButton, CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
                 child.setEnabled(True)
             else:
                 # 递归处理子部件的子部件（如布局中的嵌套控件）

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -304,7 +304,7 @@ class FarmingInterfaceLeft(QWidget):
             if child.objectName() == "link_start":
                 continue
             # 检查是否为目标控件类型
-            if isinstance(child, (CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
+            if isinstance(child, (BaseButton, CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
                 child.setEnabled(False)
             else:
                 # 递归处理子部件的子部件（如布局中的嵌套控件）
@@ -318,7 +318,7 @@ class FarmingInterfaceLeft(QWidget):
             if child.objectName() == "set_windows":
                 continue
             # 检查是否为目标控件类型
-            if isinstance(child, (CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
+            if isinstance(child, (BaseButton, CheckBox, PushButton, ComboBox, SpinBox, TransparentToolButton)):
                 child.setEnabled(True)
             else:
                 # 递归处理子部件的子部件（如布局中的嵌套控件）

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -294,6 +294,7 @@ class FarmingInterfaceLeft(QWidget):
             mediator.refresh_teams_order.emit()
             self.stop_script()
             auto.clear_img_cache()
+            mediator.mirror_bar_kill_signal.emit()
 
     def _disable_setting(self, parent):
         for child in parent.children():

--- a/app/mediator.py
+++ b/app/mediator.py
@@ -18,6 +18,8 @@ class Mediator(QObject):
     warning = Signal(str)
     finished_signal = Signal()
     kill_signal = Signal()
+    mirror_signal = Signal(int, int) # 运行的当前次数和总次数
+    mirror_bar_kill_signal = Signal()
     
     # 单例实例（类变量）
     _instance = None

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -11,7 +11,7 @@ from qfluentwidgets.window.stacked_widget import StackedWidget
 
 from app import *
 from app.base_combination import LabelWithComboBox, LabelWithSpinBox, MirrorTeamCombination, \
-    MirrorSpinBox
+    MirrorSpinBox, TextProgressBar
 from app.base_tools import BaseCheckBox
 from app.language_manager import LanguageManager, SUPPORTED_GAME_LANG_NAME
 from module.config import cfg
@@ -330,7 +330,7 @@ class PageMirror(PageCard):
 
         self.get_setting()
         self.refresh()
-
+        self.bar = None
         self.connect_mediator()
 
     def __init_card(self):
@@ -409,6 +409,68 @@ class PageMirror(PageCard):
         self.vbox_advanced.addWidget(self.select_event_pack)
 
         self.card_layout.insertWidget(self.card_layout.count() - 1, self.mirror_count)
+
+
+    def _create_mirror_bar(self, current: int, total: int) -> TextProgressBar:
+        """ 创建进度条 """
+        bar = TextProgressBar(self)
+
+        bar_width = int(200)
+        bar_height = int(bar_width / 10)
+        bar.setFixedHeight(bar_height)
+        bar.setFixedWidth(bar_width)
+        QT_TRANSLATE_NOOP("PageCard", "镜 牢 进 度 ")
+        text = self.tr("镜 牢 进 度 ")
+
+        x = (
+            self.mirror_count.width() / 2
+            - bar_width / 2
+            + self.mirror_count.box.width() / 4
+        )
+        y = 530
+        if total >= 9000:
+            bar.setFormat(f"{text}: %v / ∞")
+        else:
+            bar.setFormat(f"{text}: %v / %m")
+
+        bar.move(int(x), int(y))
+        bar.show()
+        bar.setRange(0, total)
+        bar.setValue(current)
+
+        return bar
+
+    
+    def update_mirror_bar(self, current: int, total: int):
+        """ 更新进度条 若不存在则新建"""
+        if self.bar is not None:
+            text = self.tr("镜 牢 进 度 ")
+            if total > self.bar.maximum() and total > 0:
+                self.bar.setRange(0, total)
+            self.bar.setValue(current)
+            if total >= 9000:
+                self.bar.specialValue = current
+                self.bar.setFormat(f"{text}: %raw / ∞")
+                self.bar.setValue(total)
+                self.bar.setUseAni(False)
+            elif total <= 0:
+                self.bar.hide()
+                self.bar.setFormat(f"{text}: %v / %m")
+            else:
+                if self.bar.isHidden():
+                    self.bar.show()
+                self.bar.setUseAni(True)
+                self.bar.setFormat(f"{text}: %v / %m")
+        else:
+            self.bar = self._create_mirror_bar(current, total)
+
+    def destroy_mirror_bar(self):
+        """ 销毁进度条 """
+        if self.bar is not None:
+            self.bar.hide()
+            self.bar.destroy()
+            self.bar.deleteLater()
+            self.bar = None
 
     def get_setting(self):
         team_toggle_button_group.clear()
@@ -522,6 +584,8 @@ class PageMirror(PageCard):
         # 连接所有可能信号
         mediator.delete_team_setting.connect(self.delete_team)
         mediator.refresh_teams_order.connect(self.refresh)
+        mediator.mirror_signal.connect(self.update_mirror_bar)
+        mediator.mirror_bar_kill_signal.connect(self.destroy_mirror_bar)
 
     def retranslateUi(self):
         self.mirror_count.retranslateUi()

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -116,6 +116,9 @@ class SettingInterface(ScrollArea):
             QT_TRANSLATE_NOOP("ComboBoxSettingCard", '设置程序 UI 使用的缩放'),
             texts={
                 QT_TRANSLATE_NOOP("ComboBoxSettingCard", "跟随系统"): 0,
+                "50%": 50,
+                "75%": 75,
+                "90%": 90,
                 "100%": 100,
                 "125%": 125,
                 "150%": 150,

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -486,22 +486,22 @@
         <translation>The changes will take effect after the restart</translation>
     </message>
     <message>
-        <location filename="../app/base_combination.py" line="223"/>
+        <location filename="../app/base_combination.py" line="224"/>
         <source>已复制到剪切板</source>
         <translation>Copied to clipboard</translation>
     </message>
     <message>
-        <location filename="../app/base_combination.py" line="241"/>
+        <location filename="../app/base_combination.py" line="242"/>
         <source>该设置不属于 AALC</source>
         <translation>This setting does not belong to AALC</translation>
     </message>
     <message>
-        <location filename="../app/base_combination.py" line="252"/>
+        <location filename="../app/base_combination.py" line="253"/>
         <source>不是有效的 AALC 设置</source>
         <translation>Not a valid AALC setting</translation>
     </message>
     <message>
-        <location filename="../app/base_combination.py" line="266"/>
+        <location filename="../app/base_combination.py" line="267"/>
         <source>已粘贴设置</source>
         <translation>Settings pasted</translation>
     </message>
@@ -525,7 +525,7 @@
 <context>
     <name>BaseLabel</name>
     <message>
-        <location filename="../app/farming_interface.py" line="148"/>
+        <location filename="../app/farming_interface.py" line="149"/>
         <source>之后</source>
         <translation>After</translation>
     </message>
@@ -664,32 +664,32 @@
 <context>
     <name>CheckBoxWithButton</name>
     <message>
-        <location filename="../app/farming_interface.py" line="98"/>
+        <location filename="../app/farming_interface.py" line="99"/>
         <source>窗口设置</source>
         <translation>Win-Settings</translation>
     </message>
     <message>
-        <location filename="../app/farming_interface.py" line="106"/>
+        <location filename="../app/farming_interface.py" line="107"/>
         <source>日常任务</source>
         <translation>Daily Tasks</translation>
     </message>
     <message>
-        <location filename="../app/farming_interface.py" line="113"/>
+        <location filename="../app/farming_interface.py" line="114"/>
         <source>领取奖励</source>
         <translation>Claim Rewards</translation>
     </message>
     <message>
-        <location filename="../app/farming_interface.py" line="119"/>
+        <location filename="../app/farming_interface.py" line="120"/>
         <source>狂气换体</source>
         <translation>Lunacy2Enk</translation>
     </message>
     <message>
-        <location filename="../app/farming_interface.py" line="125"/>
+        <location filename="../app/farming_interface.py" line="126"/>
         <source>坐牢设置</source>
         <translation>Mir-Settings</translation>
     </message>
     <message>
-        <location filename="../app/farming_interface.py" line="131"/>
+        <location filename="../app/farming_interface.py" line="132"/>
         <source>亚哈共鸣</source>
         <translation>Ahab-Res</translation>
     </message>
@@ -1191,7 +1191,7 @@
 <context>
     <name>MessageBoxEdit</name>
     <message>
-        <location filename="../app/base_combination.py" line="283"/>
+        <location filename="../app/base_combination.py" line="284"/>
         <source>设置备注名</source>
         <translation>Set a Custom Name</translation>
     </message>
@@ -1267,7 +1267,7 @@
 <context>
     <name>MirrorTeamCombination</name>
     <message>
-        <location filename="../app/base_combination.py" line="303"/>
+        <location filename="../app/base_combination.py" line="304"/>
         <source>备注名</source>
         <translation>Nickname</translation>
     </message>
@@ -1277,7 +1277,7 @@
         <translation>Team1</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="433"/>
+        <location filename="../app/page_card.py" line="496"/>
         <source>编队</source>
         <translation>Team</translation>
     </message>
@@ -1292,12 +1292,12 @@
 <context>
     <name>NormalTextButton</name>
     <message>
-        <location filename="../app/farming_interface.py" line="139"/>
+        <location filename="../app/farming_interface.py" line="140"/>
         <source>全选</source>
         <translation>Select All</translation>
     </message>
     <message>
-        <location filename="../app/farming_interface.py" line="144"/>
+        <location filename="../app/farming_interface.py" line="145"/>
         <source>清空</source>
         <translation>Clear All</translation>
     </message>
@@ -1320,6 +1320,20 @@
         <location filename="../app/page_card.py" line="74"/>
         <source>高级设置</source>
         <translation>Advanced</translation>
+    </message>
+    <message>
+        <location filename="../app/page_card.py" line="423"/>
+        <source>镜 牢 进 度 </source>
+        <translation type="finished">Mirror Progress</translation>
+    </message>
+</context>
+<context>
+    <name>PageMirror</name>
+    <message>
+        <location filename="../app/page_card.py" line="424"/>
+        <location filename="../app/page_card.py" line="449"/>
+        <source>镜 牢 进 度 </source>
+        <translation>Mirror Progress</translation>
     </message>
 </context>
 <context>
@@ -1377,7 +1391,7 @@
         <translation>Mirror Chyan CDK</translation>
     </message>
     <message>
-        <location filename="../app/base_combination.py" line="498"/>
+        <location filename="../app/base_combination.py" line="499"/>
         <source>获取 CDK</source>
         <translation>Get CDK</translation>
     </message>
@@ -1432,15 +1446,15 @@
 <context>
     <name>SwitchSettingCard</name>
     <message>
-        <location filename="../app/base_combination.py" line="513"/>
-        <location filename="../app/base_combination.py" line="534"/>
-        <location filename="../app/base_combination.py" line="537"/>
+        <location filename="../app/base_combination.py" line="514"/>
+        <location filename="../app/base_combination.py" line="535"/>
+        <location filename="../app/base_combination.py" line="538"/>
         <source>关</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../app/base_combination.py" line="534"/>
-        <location filename="../app/base_combination.py" line="537"/>
+        <location filename="../app/base_combination.py" line="535"/>
+        <location filename="../app/base_combination.py" line="538"/>
         <source>开</source>
         <translation>ON</translation>
     </message>
@@ -1710,24 +1724,24 @@ Update Logs:</translation>
 <context>
     <name>WindowsToast</name>
     <message>
-        <location filename="../app/windows_toast.py" line="125"/>
+        <location filename="../app/windows_toast.py" line="132"/>
         <source>知道了</source>
         <translation>I Knew</translation>
     </message>
     <message>
-        <location filename="../app/windows_toast.py" line="128"/>
+        <location filename="../app/windows_toast.py" line="135"/>
         <source>关闭 AALC</source>
         <translation>Shut Down AALC</translation>
     </message>
     <message>
-        <location filename="../tasks/base/script_task_scheme.py" line="239"/>
+        <location filename="../tasks/base/script_task_scheme.py" line="249"/>
         <source>AALC 运行结束</source>
-        <translation type="finished">AALC Missions Completed</translation>
+        <translation>AALC Missions Completed</translation>
     </message>
     <message>
-        <location filename="../tasks/base/script_task_scheme.py" line="240"/>
+        <location filename="../tasks/base/script_task_scheme.py" line="250"/>
         <source>所有任务已完成</source>
-        <translation type="finished">All Tasks Done</translation>
+        <translation>All Tasks Done</translation>
     </message>
 </context>
 </TS>

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -175,7 +175,8 @@ def script_task() -> None | int:
             mir_times = 9999
         if cfg.save_rewards and cfg.hard_mirror:
             mir_times = 1
-
+        finish_times = 0
+        mediator.mirror_signal.emit(0, mir_times)
         # 开始执行镜牢任务
         while mir_times > 0:
             # 检测配置的队伍能否顺利执行
@@ -230,6 +231,11 @@ def script_task() -> None | int:
                     if chance == 0:
                         cfg.set_value("hard_mirror", False)
 
+                # 更新进度条
+                finish_times += 1
+                mediator.mirror_signal.emit(finish_times, mir_times)
+
+        mediator.mirror_bar_kill_signal.emit()
         if cfg.re_claim_rewards:
             to_get_reward()
 

--- a/tasks/battle/battle.py
+++ b/tasks/battle/battle.py
@@ -337,7 +337,8 @@ class Battle:
         except Exception as e:
             return False
 
-    def _defense_first_round(self):
+    @staticmethod
+    def _defense_first_round(move_back: bool = False) -> bool:
         try:
             scale = cfg.set_win_size / 1440
 
@@ -366,8 +367,9 @@ class Battle:
 
             auto.mouse_drag_link(skill_list)
 
-            auto.mouse_to_blank()
+            auto.mouse_to_blank(move_back=move_back)
 
             sleep(1)
+            return True
         except Exception as e:
             return False


### PR DESCRIPTION
[feat: 显示当前运行的镜牢次数](https://github.com/KIYI671/AhabAssistantLimbusCompany/commit/370ba5fe49997a8aa7edba96e51ce769d0706961)
在 `坐牢次数` 的次数选择框上方添加了一个进度条用以显示运行的次数
![PixPin_2025-10-01_02-50-27](https://github.com/user-attachments/assets/1020e2f7-634e-48ef-9a0c-f079cfbcce11)


[feat: 为小工具添加一键守备] (https://github.com/KIYI671/AhabAssistantLimbusCompany/commit/972b25260297be30c237c89d6575dec68fec59d6) #264 

额外改动:
- 对窗口设置分成了前台和后台两种 (后台不记录和还原z序)
- 现在会在结束运行但不关闭小工具下重置窗口
- 添加了快捷键监听以快捷结束脚本
- 调整了部分文本
- 修改等待行为, 根据失败次数提高时长 (幅度较小)
- `_ocr_battle` 在后台模式启用时不再保持选中