### PR TITLE
重构后台鼠标移动和点击方法 | 错误修复

### DIFF
--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -60,6 +60,11 @@
         <translation>Hard mirror single bonus</translation>
     </message>
     <message>
+        <location filename="../app/page_card.py" line="393"/>
+        <source>第五层跳过（最左边）活动卡包</source>
+        <translation type="finished">No select the leftmost theme pack on the fifth floor</translation>
+    </message>
+    <message>
         <location filename="../app/team_setting_card.py" line="387"/>
         <source>不治疗罪人</source>
         <translation>No heal sinners</translation>
@@ -199,9 +204,9 @@
         <translation>defense first round in normal encounters</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="393"/>
+        <location filename="../app/page_card.py" line="398"/>
         <source>再次领取奖励</source>
-        <translation>re claim rewards again</translation>
+        <translation>Claim rewards again</translation>
     </message>
 </context>
 <context>
@@ -480,8 +485,8 @@
         <translation>Checking update failed (╥╯﹏╰╥)</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="305"/>
-        <location filename="../app/setting_interface.py" line="316"/>
+        <location filename="../app/setting_interface.py" line="308"/>
+        <location filename="../app/setting_interface.py" line="319"/>
         <source>更改将在重新启动后生效</source>
         <translation>The changes will take effect after the restart</translation>
     </message>
@@ -506,18 +511,18 @@
         <translation>Settings pasted</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="281"/>
+        <location filename="../app/setting_interface.py" line="284"/>
         <source>10次截图平均耗时 {time:.2f} ms</source>
         <translation>Average screenshot time over 10 attempts: {time:.2f} ms</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="282"/>
-        <location filename="../app/setting_interface.py" line="294"/>
+        <location filename="../app/setting_interface.py" line="285"/>
+        <location filename="../app/setting_interface.py" line="297"/>
         <source>截图测试结束</source>
         <translation>Screenshot test completed</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="293"/>
+        <location filename="../app/setting_interface.py" line="296"/>
         <source>截图性能测试失败</source>
         <translation>Screenshot performance test failed</translation>
     </message>
@@ -538,39 +543,39 @@
 <context>
     <name>BasePrimaryPushSettingCard</name>
     <message>
-        <location filename="../app/setting_interface.py" line="164"/>
+        <location filename="../app/setting_interface.py" line="167"/>
         <source>日志</source>
         <translation>Logs</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="166"/>
+        <location filename="../app/setting_interface.py" line="169"/>
         <source>打开日志文件夹</source>
         <translation>Open logs folder</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="175"/>
-        <location filename="../app/setting_interface.py" line="177"/>
+        <location filename="../app/setting_interface.py" line="178"/>
+        <location filename="../app/setting_interface.py" line="180"/>
         <source>项目主页</source>
         <translation>Object repo</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="181"/>
+        <location filename="../app/setting_interface.py" line="184"/>
         <source>加入群聊</source>
         <translation>Join QQ group</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="183"/>
+        <location filename="../app/setting_interface.py" line="186"/>
         <source>QQ群</source>
         <translation>QQ group</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="187"/>
-        <location filename="../app/setting_interface.py" line="189"/>
+        <location filename="../app/setting_interface.py" line="190"/>
+        <location filename="../app/setting_interface.py" line="192"/>
         <source>提供反馈</source>
         <translation>Feedback</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="191"/>
+        <location filename="../app/setting_interface.py" line="194"/>
         <source>帮助我们改进 AhabAssistantLimbusCompany</source>
         <translation>Help us to enhance AhabAssistantLimbusCompany</translation>
     </message>
@@ -636,17 +641,17 @@
         <translation>Personalization</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="129"/>
+        <location filename="../app/setting_interface.py" line="132"/>
         <source>更新设置</source>
         <translation>Update Settings</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="160"/>
+        <location filename="../app/setting_interface.py" line="163"/>
         <source>日志设置</source>
         <translation>logs Settings</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="171"/>
+        <location filename="../app/setting_interface.py" line="174"/>
         <source>关于</source>
         <translation>About</translation>
     </message>
@@ -656,7 +661,7 @@
         <translation>Toolbox</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="194"/>
+        <location filename="../app/setting_interface.py" line="197"/>
         <source>实验性内容</source>
         <translation>Experimental sections</translation>
     </message>
@@ -804,22 +809,22 @@
         <translation>Set program language</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="142"/>
+        <location filename="../app/setting_interface.py" line="145"/>
         <source>更新源</source>
         <translation>Update source</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="143"/>
+        <location filename="../app/setting_interface.py" line="146"/>
         <source>选择更新源</source>
         <translation>Choose update source</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="145"/>
+        <location filename="../app/setting_interface.py" line="148"/>
         <source>Github源</source>
         <translation>Github</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="146"/>
+        <location filename="../app/setting_interface.py" line="149"/>
         <source>Mirror 酱</source>
         <translation>Mirror Chyan</translation>
     </message>
@@ -1277,7 +1282,7 @@
         <translation>Team1</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="496"/>
+        <location filename="../app/page_card.py" line="502"/>
         <source>编队</source>
         <translation>Team</translation>
     </message>
@@ -1322,16 +1327,16 @@
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="423"/>
+        <location filename="../app/page_card.py" line="430"/>
         <source>镜 牢 进 度 </source>
-        <translation type="finished">Mirror Progress</translation>
+        <translation>Mirror Progress</translation>
     </message>
 </context>
 <context>
     <name>PageMirror</name>
     <message>
-        <location filename="../app/page_card.py" line="424"/>
-        <location filename="../app/page_card.py" line="449"/>
+        <location filename="../app/page_card.py" line="432"/>
+        <location filename="../app/page_card.py" line="455"/>
         <source>镜 牢 进 度 </source>
         <translation>Mirror Progress</translation>
     </message>
@@ -1381,12 +1386,12 @@
 <context>
     <name>PushSettingCardMirrorchyan</name>
     <message>
-        <location filename="../app/setting_interface.py" line="151"/>
+        <location filename="../app/setting_interface.py" line="154"/>
         <source>修改</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="153"/>
+        <location filename="../app/setting_interface.py" line="156"/>
         <source>Mirror 酱 CDK</source>
         <translation>Mirror Chyan CDK</translation>
     </message>
@@ -1459,7 +1464,7 @@
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="134"/>
+        <location filename="../app/setting_interface.py" line="137"/>
         <source>加入预览版更新渠道</source>
         <translation>Join Beta update</translation>
     </message>
@@ -1472,7 +1477,7 @@
         <translation type="vanished">Auto clear up logs from a week ago</translation>
     </message>
     <message>
-        <location filename="../app/setting_interface.py" line="200"/>
+        <location filename="../app/setting_interface.py" line="203"/>
         <source>自动检测并切换游戏语言</source>
         <translation>Auto identify and switch game language</translation>
     </message>

--- a/module/automation/input.py
+++ b/module/automation/input.py
@@ -238,13 +238,31 @@ class BackgroundInput(Input, metaclass=SingletonMeta):
     \n 除了不支持滚轮事件, 其余同 `Input` 类
     """
 
-    def mouse_to_blank(self, coordinate=(1, 1), move_back=False) -> None:
+    def mouse_to_blank(self, coordinate=(1, 1), move_back=True) -> None:
         """鼠标移动到空白位置，避免遮挡（然而为了避免影响用户操作，这个暂时没用）
         Args:
             coordinate (tuple): 坐标元组 (x, y)
             move_back (bool): 是否在移动后将鼠标移动回原位置
         """
         # FIXME：既不能影响用户操作，也要避免遮挡，似乎没有好办法
+        # FIXME：目前是不在游戏窗口内不移动鼠标, 但是我觉得应该把这个功能集成在截图里 - 233 25.10.4
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+            rect = win32gui.GetWindowRect(screen.handle._hWnd)
+            if (
+                current_mouse_position[0] > rect[0] + rect[2]
+                or current_mouse_position[1] > rect[1] + rect[3]
+            ):
+                # 在窗口右下角外
+                log.debug("当前鼠标位置不在游戏窗口内，取消移动到空白", stacklevel=2)
+                return
+            elif (
+                current_mouse_position[0] < rect[0]
+                or current_mouse_position[1] < rect[1]
+            ):
+                # 在窗口左上角外
+                log.debug("当前鼠标位置不在游戏窗口内，取消移动到空白", stacklevel=2)
+                return
         self._mouse_move_to(coordinate[0], coordinate[1])
 
         log.debug("鼠标移动到空白，避免遮挡", stacklevel=2)

--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -425,23 +425,6 @@ class Mirror:
                 continue
             if auto.click_element("mirror/claim_reward/rewards_acquired_assets.png"):
                 continue
-            if cfg.no_weekly_bonuses:
-                bonuses = auto.find_element("mirror/claim_reward/weekly_bonuses.png",
-                                            find_type='image_with_multiple_targets')
-                if len(bonuses) >= 1:
-                    for _ in range(len(bonuses)):
-                        position = bonuses.pop(-1)
-                        auto.mouse_click(position[0], position[1])
-            if cfg.hard_mirror_single_bonuses:
-                log.debug("开启了困牢单次领取奖励，如果存在多次奖励，则将单次领取")
-                sleep(1)
-                bonuses = auto.find_element("mirror/claim_reward/weekly_bonuses.png",
-                                            find_type='image_with_multiple_targets', take_screenshot=True)
-                bonuses = sorted(bonuses, key=lambda x: x[0])
-                if len(bonuses) > 1:
-                    for _ in range(len(bonuses) - 1):
-                        position = bonuses.pop(-1)
-                        auto.mouse_click(position[0], position[1])
             if auto.click_element("mirror/claim_reward/claim_rewards_confirm_assets.png", threshold=0.75, model='clam',
                                   take_screenshot=True):
                 continue
@@ -461,6 +444,31 @@ class Mirror:
                     continue
                 elif auto.click_element("mirror/claim_reward/claim_rewards_assets.png"):
                     sleep(1)
+                    if cfg.no_weekly_bonuses:
+                        bonuses = auto.find_element(
+                            "mirror/claim_reward/weekly_bonuses.png",
+                            find_type="image_with_multiple_targets",
+                        )
+                        if len(bonuses) >= 1:
+                            for _ in range(len(bonuses)):
+                                position = bonuses.pop(-1)
+                                auto.mouse_click(position[0], position[1])
+                    if cfg.hard_mirror_single_bonuses:
+                        log.debug(
+                            "开启了困牢单次领取奖励，如果存在多次奖励，则将单次领取"
+                        )
+                        sleep(1)
+                        bonuses = auto.find_element(
+                            "mirror/claim_reward/weekly_bonuses.png",
+                            find_type="image_with_multiple_targets",
+                            take_screenshot=True,
+                        )
+                        bonuses = sorted(bonuses, key=lambda x: x[0])
+                        if len(bonuses) > 1:
+                            for _ in range(len(bonuses) - 1):
+                                position = bonuses.pop(-1)
+                                auto.mouse_click(position[0], position[1])
+
                     if auto.click_element("mirror/claim_reward/use_enkephalin_assets.png", take_screenshot=True):
                         sleep(1)
                     # TODO: 统计获取的coins

--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -226,7 +226,7 @@ class Mirror:
                         ImageUtils.load_image("mirror/road_in_mir/get_floor_bbox.png"))
                     sc = ImageUtils.crop(np.array(auto.screenshot), get_floor_bbox)
                     mask = cv2.inRange(sc, 75, 255)
-                    for _ in range(5):
+                    for i in range(5):
                         try:
                             result = ocr.run(mask)
                             ocr_result = [result.txts[i] for i in range(len(result.txts))]
@@ -249,6 +249,12 @@ class Mirror:
                                     self.get_floor_num = False
                                     break
                         except:
+                            while auto.take_screenshot() is None:
+                                continue
+                            get_floor_bbox = ImageUtils.get_bbox(
+                                ImageUtils.load_image("mirror/road_in_mir/get_floor_bbox.png"))
+                            sc = ImageUtils.crop(np.array(auto.screenshot), get_floor_bbox)
+                            mask = cv2.inRange(sc, int(75 - i * 2.5), 255)
                             continue
                     if self.floor - 1 == self.mirror_map.floor:
                         self.mirror_map.next_floor()


### PR DESCRIPTION
- 重构 `mouse_to_blank`, 在鼠标不位于游戏工作区内时不移动鼠标 (move_back为True下)
-  移动领取奖励时的对于单次加成的处理位置, 确保是在点击了 "领取奖励" 按钮之后和 "使用脑啡肽" 按钮之前, 以防止点击后者出现的弹窗遮挡