### PR TITLE
支持跳过常规换体行为 | OCR 设置修改(并发, 图像) | 错误修复

### DIFF
--- a/app/page_card.py
+++ b/app/page_card.py
@@ -309,14 +309,23 @@ class PageLunacyToEnkephalin(PageCard):
             center=False
         )
 
+        self.skip_enkephalin = BaseCheckBox(
+            "skip_enkephalin", None,
+            QT_TRANSLATE_NOOP("BaseCheckBox", "不自动兑换脑啡肽 (?)"),
+            tips=QT_TRANSLATE_NOOP("BaseCheckBox", "勾选后除狂气换体以外不执行兑换脑啡肽的操作"),
+            center=False
+        )
+
     def __init_layout(self):
         self.vbox_general.addWidget(self.set_lunacy_to_enkephalin)
 
         self.vbox_advanced.addWidget(self.Dr_Grandet_mode)
+        self.vbox_advanced.addWidget(self.skip_enkephalin)
 
     def retranslateUi(self):
         self.set_lunacy_to_enkephalin.retranslateUi()
         self.Dr_Grandet_mode.retranslateUi()
+        self.skip_enkephalin.retranslateUi()
         super().retranslateUi()
 
 

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -70,6 +70,7 @@ set_get_prize: 0 # 0 领取邮件和通行证日常与周常，1 只领取通行
 buy_enkephalin: False # 是否自动购买体力
 set_lunacy_to_enkephalin: 2 # 0 不购买，1 购买一次，2 购买两次，3 购买三次
 Dr_Grandet_mode: False
+skip_enkephalin: False # 跳过换体
 
 # 是否进行自动镜牢
 mirror: False # 是否进行自动镜牢

--- a/assets/config/default_rapidocr.yaml
+++ b/assets/config/default_rapidocr.yaml
@@ -1,0 +1,120 @@
+Global:
+    text_score: 0.5
+
+    use_det: true
+    use_cls: true
+    use_rec: true
+
+    min_height: 30
+    width_height_ratio: 8
+    max_side_len: 1600 # 限制最大边长为1600px
+    min_side_len: 30
+
+    return_word_box: false
+    return_single_char_box: false
+
+    font_path: null
+    log_level: "info" # debug / info / warning / error / critical
+
+EngineConfig:
+    onnxruntime:
+        intra_op_num_threads: 2 # 图像操作并行线程数 限制为 2 防止占用过多 CPU 资源 同时不损失过多性能 也能防止资源抢占 下同
+        inter_op_num_threads: 2 # 节点并行线程数
+        enable_cpu_mem_arena: false
+
+        cpu_ep_cfg:
+            arena_extend_strategy: "kSameAsRequested"
+
+        use_cuda: false
+        cuda_ep_cfg:
+            device_id: 0
+            arena_extend_strategy: "kNextPowerOfTwo"
+            cudnn_conv_algo_search: "EXHAUSTIVE"
+            do_copy_in_default_stream: true
+
+        use_dml: false
+        dm_ep_cfg: null
+
+        use_cann: false
+        cann_ep_cfg:
+            device_id: 0
+            arena_extend_strategy: "kNextPowerOfTwo"
+            npu_mem_limit:  21474836480 # 20 * 1024 * 1024 * 1024
+            op_select_impl_mode: "high_performance"
+            optypelist_for_implmode: "Gelu"
+            enable_cann_graph: true
+
+    openvino:
+        inference_num_threads: -1
+        performance_hint: null
+        performance_num_requests: -1
+        enable_cpu_pinning: null
+        num_streams: -1
+        enable_hyper_threading: null
+        scheduling_core_type: null
+
+    paddle:
+        cpu_math_library_num_threads: -1
+        use_npu: false
+        npu_id: 0
+        use_cuda: false
+        gpu_id: 0
+        gpu_mem: 500
+
+    torch:
+        use_cuda: false
+        gpu_id: 0
+
+Det:
+    engine_type: "onnxruntime"
+    lang_type: "ch"
+    model_type: "mobile"
+    ocr_version: "PP-OCRv4"
+
+    task_type: "det"
+
+    model_path: null
+    model_dir: null
+
+    limit_side_len: 736
+    limit_type: min
+    std: [ 0.5, 0.5, 0.5 ]
+    mean: [ 0.5, 0.5, 0.5 ]
+
+    thresh: 0.3
+    box_thresh: 0.5
+    max_candidates: 1000
+    unclip_ratio: 1.6
+    use_dilation: true
+    score_mode: fast
+
+Cls:
+    engine_type: "onnxruntime"
+    lang_type: "ch"
+    model_type: "mobile"
+    ocr_version: "PP-OCRv4"
+
+    task_type: "cls"
+
+    model_path: null
+    model_dir: null
+
+    cls_image_shape: [3, 48, 192]
+    cls_batch_num: 6
+    cls_thresh: 0.9
+    label_list: ["0", "180"]
+
+Rec:
+    engine_type: "onnxruntime"
+    lang_type: "ch"
+    model_type: "mobile"
+    ocr_version: "PP-OCRv4"
+
+    task_type: "rec"
+
+    model_path: null
+    model_dir: null
+
+    rec_keys_path: null
+    rec_img_shape: [3, 48, 320]
+    rec_batch_num: 6

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -30,39 +30,49 @@
         <translation>Grandet mode</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="355"/>
+        <location filename="../app/page_card.py" line="314"/>
+        <source>不自动兑换脑啡肽 (?)</source>
+        <translation type="finished">Do not automatic exchange enkephalin (?)</translation>
+    </message>
+    <message>
+        <location filename="../app/page_card.py" line="315"/>
+        <source>勾选后除狂气换体以外不执行兑换脑啡肽的操作</source>
+        <translation type="finished">After checking, do not perform the operation of exchanging enkephalin except for lunacy to enkephalin</translation>
+    </message>
+    <message>
+        <location filename="../app/page_card.py" line="364"/>
         <source>使用困难镜牢*</source>
         <translation>Hard mode*</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="361"/>
+        <location filename="../app/page_card.py" line="370"/>
         <source>不使用每周加成*</source>
         <translation>Non-weekly bonus*</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="367"/>
+        <location filename="../app/page_card.py" line="376"/>
         <source>只打三层</source>
         <translation>Only floor 3</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="372"/>
+        <location filename="../app/page_card.py" line="381"/>
         <source>无限坐牢</source>
         <translation>Infinite farming</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="377"/>
+        <location filename="../app/page_card.py" line="386"/>
         <source>保存困牢奖励</source>
         <translation>Save hard mirror rewards</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="383"/>
+        <location filename="../app/page_card.py" line="392"/>
         <source>困牢单次加成</source>
         <translation>Hard mirror single bonus</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="393"/>
+        <location filename="../app/page_card.py" line="402"/>
         <source>第五层跳过（最左边）活动卡包</source>
-        <translation type="finished">No select the leftmost theme pack on the fifth floor</translation>
+        <translation>No select the leftmost theme pack on the fifth floor</translation>
     </message>
     <message>
         <location filename="../app/team_setting_card.py" line="387"/>
@@ -178,18 +188,18 @@
         <translation>Only formula fuse</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="358"/>
-        <location filename="../app/page_card.py" line="364"/>
+        <location filename="../app/page_card.py" line="367"/>
+        <location filename="../app/page_card.py" line="373"/>
         <source>仅本次运行期间有效，重启AALC后失效</source>
         <translation>Only effective for this run, invalid after restart</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="378"/>
+        <location filename="../app/page_card.py" line="387"/>
         <source>仅在进行困难镜牢时生效，普通难度不生效</source>
         <translation>Only effective for hard mirror, ineffective for normal mirror</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="388"/>
+        <location filename="../app/page_card.py" line="397"/>
         <source>第五层选择（最左边）活动卡包</source>
         <translation>Select the leftmost theme pack on the fifth floor</translation>
     </message>
@@ -204,7 +214,7 @@
         <translation>defense first round in normal encounters</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="398"/>
+        <location filename="../app/page_card.py" line="407"/>
         <source>再次领取奖励</source>
         <translation>Claim rewards again</translation>
     </message>
@@ -1264,7 +1274,7 @@
 <context>
     <name>MirrorSpinBox</name>
     <message>
-        <location filename="../app/page_card.py" line="344"/>
+        <location filename="../app/page_card.py" line="353"/>
         <source>坐牢次数</source>
         <translation>Farming times</translation>
     </message>
@@ -1277,12 +1287,12 @@
         <translation>Nickname</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="339"/>
+        <location filename="../app/page_card.py" line="348"/>
         <source>编队1</source>
         <translation>Team1</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="502"/>
+        <location filename="../app/page_card.py" line="511"/>
         <source>编队</source>
         <translation>Team</translation>
     </message>
@@ -1327,7 +1337,7 @@
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../app/page_card.py" line="430"/>
+        <location filename="../app/page_card.py" line="439"/>
         <source>镜 牢 进 度 </source>
         <translation>Mirror Progress</translation>
     </message>
@@ -1335,8 +1345,8 @@
 <context>
     <name>PageMirror</name>
     <message>
-        <location filename="../app/page_card.py" line="432"/>
-        <location filename="../app/page_card.py" line="455"/>
+        <location filename="../app/page_card.py" line="441"/>
+        <location filename="../app/page_card.py" line="464"/>
         <source>镜 牢 进 度 </source>
         <translation>Mirror Progress</translation>
     </message>

--- a/module/automation/input.py
+++ b/module/automation/input.py
@@ -251,8 +251,8 @@ class BackgroundInput(Input, metaclass=SingletonMeta):
             current_mouse_position = self.get_mouse_position()
             rect = win32gui.GetWindowRect(screen.handle._hWnd)
             if (
-                current_mouse_position[0] > rect[0] + rect[2]
-                or current_mouse_position[1] > rect[1] + rect[3]
+                current_mouse_position[0] > rect[2]
+                or current_mouse_position[1] > rect[3]
             ):
                 # 在窗口右下角外
                 log.debug("当前鼠标位置不在游戏窗口内，取消移动到空白", stacklevel=2)

--- a/module/automation/input.py
+++ b/module/automation/input.py
@@ -532,10 +532,9 @@ class BackgroundInput(Input, metaclass=SingletonMeta):
         except PyWinTypesError as e:
             # 奇怪的权限冲突 (183:当文件已存在时，无法创建该文件。)
             # 偶尔出现不影响使用
-            import ctypes
 
             log.debug(f"鼠标移动失败: {e}")
             try:
-                ctypes.windll.user32.SetCursorPos(x, y)
+                pyautogui.moveTo(x, y)
             except Exception as e:
                 log.error(f"鼠标移动失败: {type(e)}: {e}")

--- a/module/automation/input.py
+++ b/module/automation/input.py
@@ -437,7 +437,7 @@ class BackgroundInput(Input, metaclass=SingletonMeta):
         hwnd = screen.handle._hWnd
         long_positon = win32api.MAKELONG(x, y)
         win32api.SendMessage(hwnd, win32con.WM_LBUTTONDOWN, 0, long_positon)
-        sleep(0.0001)
+        sleep(0.01)
 
     def mouse_up(self, x, y):
         """鼠标左键抬起
@@ -450,7 +450,7 @@ class BackgroundInput(Input, metaclass=SingletonMeta):
         hwnd = screen.handle._hWnd
         long_positon = win32api.MAKELONG(x, y)
         win32api.SendMessage(hwnd, win32con.WM_LBUTTONUP, 0, long_positon)
-        sleep(0.001)
+        sleep(0.01)
 
     def set_mouse_pos(self, x, y):
         """移动光标位置

--- a/module/ocr/ocr.py
+++ b/module/ocr/ocr.py
@@ -29,7 +29,8 @@ class OCR(metaclass=SingletonMeta):
                 "Rec.lang_type": LangRec.CH,
                 "Rec.model_type": ModelType.MOBILE,
                 "Rec.ocr_version": OCRVersion.PPOCRV4,
-            }
+            },
+            config_path=r"assets\config\default_rapidocr.yaml",
         )
 
     def run(self, image: Image.Image | np.ndarray | str) -> RapidOCROutput:

--- a/tasks/base/make_enkephalin_module.py
+++ b/tasks/base/make_enkephalin_module.py
@@ -32,7 +32,14 @@ def get_the_timing():
 
 
 @begin_and_finish_time_log(task_name="体力换饼", calculate_time=False)
-def make_enkephalin_module(cancel=False):
+def make_enkephalin_module(cancel=True, skip=True):
+    """体力换饼的模块
+    Args:
+        cancel (bool): 是否点击取消按钮 (即关闭换体界面)
+        skip (bool): 是否遵循设置跳过换体 (优先于cfg.skip_enkephalin)
+    """
+    if skip and cfg.skip_enkephalin:
+        return
     import time
     start_time = time.time()
     last_log_time = None
@@ -91,7 +98,7 @@ def make_enkephalin_module(cancel=False):
 
 @begin_and_finish_time_log(task_name="狂气换体", calculate_time=False)
 def lunacy_to_enkephalin(times=0):
-    make_enkephalin_module(cancel=False)
+    make_enkephalin_module(cancel=False, skip=False)
     auto.click_element("enkephalin/use_lunacy_assets.png")
     sleep(0.5)
     Grandet = False
@@ -133,4 +140,4 @@ def lunacy_to_enkephalin(times=0):
             continue
         break
     auto.click_element("enkephalin/enkephalin_cancel_assets.png")
-    make_enkephalin_module()
+    make_enkephalin_module(skip=False)

--- a/tasks/daily/luxcavation.py
+++ b/tasks/daily/luxcavation.py
@@ -18,7 +18,8 @@ def EXP_luxcavation():
                 level = sorted(level, key=lambda x: x[0], reverse=True)
                 for lv in level:
                     auto.mouse_click(lv[0], lv[1])
-                    sleep(0.5)
+                    sleep(1)
+                    auto.mouse_to_blank()
                     if auto.find_element("battle/teams_assets.png", take_screenshot=True):
                         break
         if auto.click_element("home/luxcavation_assets.png"):
@@ -59,7 +60,8 @@ def thread_luxcavation():
                     level = sorted(level, key=lambda y: y[1], reverse=True)
                     for lv in level:
                         auto.mouse_click(lv[0], lv[1])
-                        sleep(0.5)
+                        sleep(1)
+                        auto.mouse_to_blank()
                         if auto.find_element("battle/teams_assets.png", take_screenshot=True):
                             break
             continue


### PR DESCRIPTION
我在想要不要给具有`tips`的`checkbox`加一个后缀如 `(?)` 或者 `⁽ˀ⁾`  来标识具有提示(由于问号 ? 没有上标的Unicode字符 这里用的是形状类似的[喉爆发音](https://zh.wikipedia.org/wiki/%E5%96%89%E7%88%86%E5%8F%91%E9%9F%B3))

加跳过行为的时候发现换脑啡肽函数的`cancel`默认值是`False` 而在其内部使用和外部调用中表明其默认值应为`True` 于是更改了