### PR TITLE
fix: page_card.py 507行内外引号一致导致源码运行失败

### DIFF
--- a/app/page_card.py
+++ b/app/page_card.py
@@ -504,7 +504,7 @@ class PageMirror(PageCard):
     def destroy_mirror_bar(self):
         """ 销毁进度条 """
         if self.bar is not None:
-            log.info(f"已完成{"困难镜牢" if cfg.hard_mirror else "普通镜牢"}进度 {self.bar.value()} / {self.bar.maximum()}")
+            log.info(f'已完成{"困难镜牢" if cfg.hard_mirror else "普通镜牢"}进度 {self.bar.value()} / {self.bar.maximum()}')
             self.bar.hide()
             self.bar.destroy()
             self.bar.deleteLater()


### PR DESCRIPTION
如题，在python3.11下按照readme里源码运行的方式报错：
Traceback (most recent call last):
  File "D:\Tools\AhabAssistantLimbusCompany\main.py", line 5, in <module>
    from app.my_app import MainWindow
  File "D:\Tools\AhabAssistantLimbusCompany\app\my_app.py", line 17, in <module>
    from app.farming_interface import FarmingInterface
  File "D:\Tools\AhabAssistantLimbusCompany\app\farming_interface.py", line 13, in <module>
    from app.page_card import (
  File "D:\Tools\AhabAssistantLimbusCompany\app\page_card.py", line 507
    log.info(f"已完成{"困难镜牢" if cfg.hard_mirror else "普通镜牢"}进度 {self.bar.value()} / {self.bar.maximum()}")
                    ^^^^
SyntaxError: f-string: expecting '}'

修改后已证实可以运行。