### PR TITLE
fix(logger): 解决AALC界面不能及时展示user日志的问题

### DIFF
--- a/app/mediator.py
+++ b/app/mediator.py
@@ -9,7 +9,6 @@ class Mediator(QObject):
     close_setting = Signal()
     refresh_teams_order = Signal()
     sinner_be_selected = Signal()
-    scroll_log_show = Signal(str)
     link_start = Signal()
     save_warning = Signal()
     tasks_warning = Signal()

--- a/module/logger/__init__.py
+++ b/module/logger/__init__.py
@@ -1,3 +1,5 @@
-from .my_log import Logger
+from .my_log import Logger, ui_log_dispatcher
 
 log = Logger().get_logger()
+
+__all__ = ["log", "ui_log_dispatcher"]


### PR DESCRIPTION
<del>解决了一个原来并不存在的问题</del>

* 给界面展示窗口开了个内存buffer放INFO日志，不写user.log了。<del>彻底解决了读取文件来展示日志带来的任何问题</del>

* 因为现在只写一个日志文件，可以充分利用操作系统的文件写缓存。另外目前也没有日志性能方面的问题，所以移除了`MemoryHandler`以保证意外崩溃情况下的日志完整性