### PR TITLE
chore(build): 打包时保留rapidocr默认字体

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -81,7 +81,8 @@ redundant_files = [
     "rapidocr/models/ch_PP-OCRv5_rec_mobile_infer.onnx",
     "rapidocr/models/ch_PP-OCRv5_mobile_det.onnx",
     # rapidocr用来可视化识别结果的字体，我们不用这个功能
-    "rapidocr/models/FZYTK.TTF",
+    # 但是因为rapidocr代码耦合的问题，即使不用可视化也会强制下载这个文件，所以还是留着吧...
+    # "rapidocr/models/FZYTK.TTF",
     # opencv的videoio插件，我们不需要
     "cv2/opencv_videoio_ffmpeg4110_64.dll",
 ]


### PR DESCRIPTION
Fix #389

虽然用不到，但是好像rapidocr实际上总会去下那个字体，那还是留着吧。可以避免某些情况下网络代理配置错误导致的断网影响ocr识别（issue里的情况似乎就是代理有点问题导致aalc不能联网，但是浏览器之类的都正常）