### PR TITLE
fix: 修复在托盘时，未完全加载就打开窗口问题

### DIFF
--- a/app/my_app.py
+++ b/app/my_app.py
@@ -200,8 +200,7 @@ class MainWindow(FramelessWindow):
         if not self.isVisible():
             self.setWindowOpacity(0)
             self.showNormal()
-            QApplication.processEvents()
-            self.setWindowOpacity(1)
+            QTimer.singleShot(0, lambda: self.setWindowOpacity(1))
         else:
             self.showNormal()
 


### PR DESCRIPTION
托盘打开主窗口，没有完全加载就会打开。导致会有一个纯白色窗口闪烁效果。