### PR TITLE
fix:兼容购买初始化报错

### DIFF
--- a/tasks/teams/team_formation.py
+++ b/tasks/teams/team_formation.py
@@ -61,6 +61,7 @@ def select_battle_team(num):
     ) and auto.find_element("home/back_assets.png", model="normal"):
         auto.click_element("home/back_assets.png")
     if position := auto.find_element("battle/teams_assets.png", take_screenshot=True):
+        auto.mouse_click(1,1)
         my_position[0] += position[0]
         my_position[1] += position[1]
         for _ in range(3):


### PR DESCRIPTION
在寻找队伍前先点击一下(1,1)，关闭购买初始化失败提示窗口，以免导致队伍寻找上滑操作被阻挡