### PR TITLE
fix(simulator): mouse_to_blank重载unexpected keyword argument 'move back'

### DIFF
--- a/module/simulator/simulator_control.py
+++ b/module/simulator/simulator_control.py
@@ -265,7 +265,7 @@ class SimulatorControl:
         self.wait_pause()
         return True
 
-    def mouse_to_blank(self, coordinate=(1, 1)) -> None:  # background未重载
+    def mouse_to_blank(self, coordinate=(1, 1), move_back=False) -> None:  # background未重载
         """占位"""
         return
 


### PR DESCRIPTION
SimulatorControl的mouse_to_blank占位缺少move_back这个input argument，给加上了