### PR TITLE
fix: 纠正SetProcessDpiAwareness调用，提高DPI感知等级

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ import socket
 import sys
 import threading
 
+# 解决 Windows DPI 缩放问题
+from ctypes import windll
+windll.shcore.SetProcessDpiAwareness(2)
+
 from app.language_manager import LanguageManager
 from app.my_app import MainWindow
 from module.config import cfg

--- a/main_dev.py
+++ b/main_dev.py
@@ -22,6 +22,10 @@ import threading
 import time
 from pathlib import Path
 
+# 解决 Windows DPI 缩放问题
+from ctypes import windll
+windll.shcore.SetProcessDpiAwareness(2)
+
 from module.logger import log
 
 try:

--- a/module/game_and_screen/screen.py
+++ b/module/game_and_screen/screen.py
@@ -1,4 +1,3 @@
-from ctypes import windll
 from time import sleep
 from typing import TYPE_CHECKING, overload
 
@@ -343,9 +342,6 @@ class Screen(metaclass=SingletonMeta):
         """通过调整窗口置顶减少误触"""
         # 获取适用于win32gui与win32con的窗口句柄
         hwnd = self.handle.hwnd
-
-        # 告诉系统当前进程是 DPI 感知的,确保窗口在高 DPI 系统上正确显示,并适应不同的 DPI 缩放
-        windll.user32.SetProcessDPIAware()
 
         # 设置窗口始终置顶
         if not cfg.background_click:


### PR DESCRIPTION
# 纠正SetProcessDpiAwareness调用，提高DPI感知等级

## 问题发现

### 多屏幕DPI不同时分辨率获取不正确

在多屏幕不同缩放的情况下发现的问题，比如我有两个显示一个1和2，其中1是100%缩放，主显示器，2是125%缩放，如果游戏在2显示器上，程序获取分辨率的时候由于dwm虚拟化的原因会将真实分辨率除以缩放系数，导致程序认为分辨率过小

### 现有DPI等级函数调用不对

现有调用在这里
https://github.com/KIYI671/AhabAssistantLimbusCompany/blob/07ba5524171502bcc81d01c7d8d5e82eb1685fac/module/game_and_screen/screen.py#L347-L348
但是实际上，SetProcessDpiAwareness在自身gui出现之前就应该被调用，在自身GUI出现后，系统不再接受DPI探测等级的修改，(详见此[https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process#setting-default-awareness-programmatically](https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process#setting-default-awareness-programmatically))并且只有等级为2时，才能获取不同DPI屏幕下的真实分辨率，目前我是在main的开头调用了此函数调整感知等级，此外，可以通过应用程序清单来设置，不过这个目前没看还（在使用pyinstaller打包成exe时可用）

此外，不知是什么原因，能在终端看到如下字样
```terminal
[DEBUG] 2026-03-04 03:23:35,502 [AALC] module\automation\automation.py:58: 使用后台点击模块
qt.qpa.window: SetProcessDpiAwarenessContext() failed: 拒绝访问。
Qt's default DPI awareness context is DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2. If you know what you are doing, you can overwrite this default using qt.conf (https://doc.qt.io/qt-6/highdpi.html#configuring-windows).
[DEBUG] 2026-03-04 03:23:37,347 [AALC] app\my_app.py:93: 注册翻译组件: MainWindow
[DEBUG] 2026-03-04 03:23:37,386 [AALC] app\farming_interface.py:119: 注册翻译组件: FarmingInterfaceLeft
```

