### PR TITLE
修复SetProcessDpiAwarenessContext传参问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,12 +4,12 @@ import sys
 import threading
 
 # 解决 Windows DPI 缩放问题
-from ctypes import windll
+from ctypes import windll, c_void_p
 
 try:
     # 1. 尝试 Win10 1703+ 的最强方案 (Per Monitor V2)
     # -4 对应 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
-    windll.user32.SetProcessDpiAwarenessContext(-4)
+    windll.user32.SetProcessDpiAwarenessContext(c_void_p(-4))
 except (AttributeError, OSError):
     try:
         # 2. 尝试 Win8.1+ 的方案 (Per Monitor)

--- a/main_dev.py
+++ b/main_dev.py
@@ -22,13 +22,13 @@ import threading
 import time
 
 # 解决 Windows DPI 缩放问题
-from ctypes import windll
+from ctypes import windll, c_void_p
 from pathlib import Path
 
 try:
     # 1. 尝试 Win10 1703+ 的最强方案 (Per Monitor V2)
     # -4 对应 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
-    windll.user32.SetProcessDpiAwarenessContext(-4)
+    windll.user32.SetProcessDpiAwarenessContext(c_void_p(-4))
 except (AttributeError, OSError):
     try:
         # 2. 尝试 Win8.1+ 的方案 (Per Monitor)


### PR DESCRIPTION
# 问题
原本的传参是这样的：
```python3
windll.user32.SetProcessDpiAwarenessContext(-4)
```
但是我本地发现没设置成功，仍然会报错分辨率过小

# 原理
从[这里](https://learn.microsoft.com/zh-cn/windows/win32/api/winuser/nf-winuser-setthreaddpiawarenesscontext)可以看到具体的API调用类型是
```C++
DPI_AWARENESS_CONTEXT SetThreadDpiAwarenessContext(
  [in] DPI_AWARENESS_CONTEXT dpiContext
);
```
去看Windows Kit中的头文件可以看到
```C
// winnt.h

#define DECLARE_HANDLE(name) struct name##__{int unused;}; typedef struct name##__ *name


// windef.h

DECLARE_HANDLE(DPI_AWARENESS_CONTEXT);

// 其他代码

#define DPI_AWARENESS_CONTEXT_UNAWARE               ((DPI_AWARENESS_CONTEXT)-1)
#define DPI_AWARENESS_CONTEXT_SYSTEM_AWARE          ((DPI_AWARENESS_CONTEXT)-2)
#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE     ((DPI_AWARENESS_CONTEXT)-3)
#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2  ((DPI_AWARENESS_CONTEXT)-4)
#define DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED     ((DPI_AWARENESS_CONTEXT)-5)
```
也就是说实际上展开宏是：
```C
struct DPI_AWARENESS_CONTEXT__{
    int unused;
    };  
typedef struct DPI_AWARENESS_CONTEXT__ *DPI_AWARENESS_CONTEXT
```
which means实际上传递的是一个结构体指针（其实是Handle），但是如果不限定任何类型，默认情况下ctypes传递参数int最终会被转换成int32，最终导致函数调用失败（这可以看函数返回值，1为成功0是失败）。所以需要传递一个`void *`类型

# 解决方法
现在更新为：
```python3
from ctypes import c_void_p
windll.user32.SetProcessDpiAwarenessContext(c_void_p(-4))
```
即可正确设置
