### PR TITLE
修复其他模拟器重启时只能关闭游戏无法重新启动的问题

### DIFF
--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -144,7 +144,8 @@ def init_game():
             from module.automation.input_handlers.simulator.simulator_control import (
                 SimulatorControl,
             )
-
+            # 启动时先清理旧连接
+            SimulatorControl.clean_connect()
             simulator = SimulatorControl()
     auto.init_input()
     if cfg.simulator:


### PR DESCRIPTION
原先旧链接没有被彻底清理，导致在重新连接时依旧使用旧链接，使等待header的socket.readline()无数据可读，将进程卡死。
现在在每次启动前都会清理旧进程，保证重启时设备端的socket是新的。