### PR TITLE
fix(ui): 修复spinbox错误地全部使用hard_mirror_chance为默认值

### DIFF
--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -892,9 +892,9 @@ class PushSettingCardChance(BasePushSettingCard):
         text,
         icon: Union[str, QIcon, FluentIconBase],
         title,
+        config_name: str,
         max_value=3,
         content=None,
-        config_name: str = None,
         parent=None,
     ):
         super().__init__(text, icon, title, content, parent)
@@ -910,7 +910,12 @@ class PushSettingCardChance(BasePushSettingCard):
         self.button.clicked.connect(self.__onclicked)
 
     def __onclicked(self):
-        message_box = MessageBoxSpinbox(self.tr(self.title), self.window(), self.max_value)
+        message_box = MessageBoxSpinbox(
+            self.tr(self.title),
+            config_name=self.config_name,
+            parent=self.window(),
+            max_value=self.max_value,
+        )
         if message_box.exec():
             cfg.set_value(f"{self.config_name}", int(message_box.getValue()))
             self.line_text.setText(str(message_box.getValue()))

--- a/app/card/messagebox_custom.py
+++ b/app/card/messagebox_custom.py
@@ -432,7 +432,7 @@ class MessageBoxDate(MessageBox):
 
 
 class MessageBoxSpinbox(MessageBox):
-    def __init__(self, title: str, parent=None, max_value=3):
+    def __init__(self, title: str, config_name: str, parent=None, max_value=3):
         super().__init__(title, "", parent)
 
         self.text = title
@@ -444,9 +444,11 @@ class MessageBoxSpinbox(MessageBox):
         self.cancelButton.setText(self.tr("取消"))
 
         self.box = SpinBox(self)
-        self.box.setValue(int(cfg.hard_mirror_chance))
+        initial_value = cfg.get_value(config_name, 0)
+        max_int = int(max_value)
         self.box.setMinimum(0)
-        self.box.setMaximum(int(max_value))
+        self.box.setMaximum(max_int)
+        self.box.setValue(int(initial_value))
 
         self.textLayout.addWidget(self.box, 0, Qt.AlignTop)
 

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -128,9 +128,11 @@ class SettingInterface(QWidget):
             QT_TRANSLATE_NOOP("PushSettingCardChance", "修改"),
             FIF.UNIT,
             QT_TRANSLATE_NOOP("PushSettingCardChance", "困难模式剩余次数"),
-            3,
-            QT_TRANSLATE_NOOP("PushSettingCardChance", "第一次运行请手动设定，之后将自动修改"),
             config_name="hard_mirror_chance",
+            max_value=3,
+            content=QT_TRANSLATE_NOOP(
+                "PushSettingCardChance", "第一次运行请手动设定，之后将自动修改"
+            ),
         )
         self.win_input_type_card = ComboBoxSettingCard(
             "win_input_type",
@@ -183,18 +185,18 @@ class SettingInterface(QWidget):
             QT_TRANSLATE_NOOP("PushSettingCardChance", "修改"),
             FIF.TRAIN,
             QT_TRANSLATE_NOOP("PushSettingCardChance", "使用的模拟器端口号"),
-            65535,
-            "",
-            "simulator_port",
+            config_name="simulator_port",
+            max_value=65535,
+            content="",
             parent=self.simulator_setting_group,
         )
         self.start_emulator_timeout_chance_card = PushSettingCardChance(
             QT_TRANSLATE_NOOP("PushSettingCardChance", "修改"),
             FIF.TRAIN,
             QT_TRANSLATE_NOOP("PushSettingCardChance", "仅限MUMU模拟器——启动模拟器超时时间(秒)"),
-            3600,
-            "",
-            "start_emulator_timeout",
+            config_name="start_emulator_timeout",
+            max_value=3600,
+            content="",
             parent=self.simulator_setting_group,
         )
 


### PR DESCRIPTION
spinbox原先会默认使用`hard_mirror_chance`的值为输入的默认值。现在强制要求`PushSettingCardChance`和`MessageBoxSpinbox`使用`config_name`以确保使用各自的值为修改默认值。