### PR TITLE
fix(battle): 修复battle中错误使用click_element

### DIFF
--- a/tasks/battle/battle.py
+++ b/tasks/battle/battle.py
@@ -200,7 +200,7 @@ class Battle:
 
             if view_status := auto.find_element("battle/view_status_assets.png", model="clam"):
                 my_scale = cfg.set_win_size / 1440
-                auto.click_element(view_status[0] + 100 * my_scale, view_status[1] - 500 * my_scale)
+                auto.mouse_click(view_status[0] + 100 * my_scale, view_status[1] - 500 * my_scale)
                 continue
 
             # 如果正在交战过程


### PR DESCRIPTION
原先使用click_element会因为ValueError报错，应使用mouse_click对应输入的x，y。