### PR TITLE
✨ feat(mirror): 优化楼层识别逻辑，增强OCR处理能力

### DIFF
--- a/module/ocr/ocr.py
+++ b/module/ocr/ocr.py
@@ -30,14 +30,37 @@ class OCR(metaclass=SingletonMeta):
     def run(self, image: Image.Image | np.ndarray | str) -> RapidOCROutput:
         """执行OCR识别，支持Image对象、文件路径和np.ndarray对象"""
         try:
-            # 将 PIL Image 对象转换为 OpenCV 图片对象
-            img_cv = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
-            # 将 OpenCV 图片对象转换为灰度模式
-            img_cv_gray = cv2.cvtColor(img_cv, cv2.COLOR_BGR2GRAY)
+            if isinstance(image, str):
+                with Image.open(image) as image_file:
+                    image_array = np.array(image_file)
+            elif isinstance(image, Image.Image):
+                image_array = np.array(image)
+            elif isinstance(image, np.ndarray):
+                image_array = image
+            else:
+                image_array = np.array(image)
+
+            if image_array.ndim == 2:
+                img_cv_gray = image_array
+            elif image_array.ndim == 3:
+                channel_count = image_array.shape[2]
+                if channel_count == 1:
+                    img_cv_gray = image_array[:, :, 0]
+                elif channel_count == 3:
+                    img_cv = cv2.cvtColor(image_array, cv2.COLOR_RGB2BGR)
+                    img_cv_gray = cv2.cvtColor(img_cv, cv2.COLOR_BGR2GRAY)
+                elif channel_count == 4:
+                    img_cv = cv2.cvtColor(image_array, cv2.COLOR_RGBA2BGR)
+                    img_cv_gray = cv2.cvtColor(img_cv, cv2.COLOR_BGR2GRAY)
+                else:
+                    raise ValueError(f"不支持的图像通道数: {channel_count}")
+            else:
+                raise ValueError(f"不支持的图像维度: {image_array.ndim}")
+
             # 自适应均衡化(均值化后更亮)
             clahe = createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
-            image = clahe.apply(img_cv_gray)
-            results = self.engine(image)
+            processed_image = clahe.apply(img_cv_gray)
+            results = self.engine(processed_image)
             self.log_results(results)
             return results
         except Exception as e:

--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -1,3 +1,4 @@
+import re
 import time
 from time import sleep
 
@@ -1346,46 +1347,82 @@ class Mirror:
         self.shop.in_shop(self.floor)
 
     def get_which_floor(self):
-        def handle_ocr(image):
+        def extract_floor_from_text(ocr_text):
+            normalized_text = ocr_text.replace(" ", "").replace("\n", "").lower()
+            floor = None
+            if cfg.language_in_game == "zh_cn":
+                for pattern in (r"第([1-5])层", r"第([1-5])层?", r"([1-5])层"):
+                    match = re.search(pattern, normalized_text)
+                    if match:
+                        floor = int(match.group(1))
+                        break
+                if floor is None and "第" in normalized_text:
+                    for char in normalized_text[normalized_text.index("第") + 1 :]:
+                        if char in "12345":
+                            floor = int(char)
+                            break
+            else:
+                for pattern in (r"floor([1-5])", r"oor([1-5])", r"([1-5])f"):
+                    match = re.search(pattern, normalized_text)
+                    if match:
+                        floor = int(match.group(1))
+                        break
+                if floor is None:
+                    anchor_index = normalized_text.find("floor")
+                    if anchor_index == -1:
+                        anchor_index = normalized_text.find("oor")
+                    if anchor_index != -1:
+                        for char in normalized_text[anchor_index:]:
+                            if char in "12345":
+                                floor = int(char)
+                                break
+            if floor is None:
+                return None
+            return floor if 0 < floor <= 5 else None
+
+        def handle_ocr(image, stage_name):
+            ocr_result = ""
             try:
                 result = ocr.run(image)
-                ocr_result = [result.txts[i] for i in range(len(result.txts))]
-                ocr_result = "".join(ocr_result)
-                log.debug(f"对于楼层信息OCR得到：{ocr_result}")
-                if cfg.language_in_game == "zh_cn" and "第" in ocr_result:
-                    result = ocr_result.split("第")
-                    floor = result[-1][0]
-                    floor = int(floor)
-                    if 0 < floor <= 5:
-                        self.floor = floor
-                        self.get_floor_num = False
-                        return True
-                elif cfg.language_in_game == "en" and "oor" in ocr_result:
-                    result = ocr_result.split("oor")
-                    floor = result[-1][0]
-                    floor = int(floor)
-                    if 0 < floor <= 5:
-                        self.floor = floor
-                        self.get_floor_num = False
-                        return True
+                if getattr(result, "txts", None):
+                    ocr_result = "".join(result.txts)
+                floor = extract_floor_from_text(ocr_result)
+                if floor is not None:
+                    log.debug(f"对于楼层信息OCR[{stage_name}]得到：{ocr_result}")
+                    self.floor = floor
+                    self.get_floor_num = False
+                    return True, ocr_result
             except:
                 pass
-            return False
+            return False, ocr_result
 
         this_floor = self.floor
 
         auto.take_screenshot(gray=False)
         get_floor_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/road_in_mir/get_floor_bbox.png"))
-        sc = ImageUtils.crop(np.array(auto.screenshot), get_floor_bbox)
+        previous_crop = ImageUtils.crop(np.array(auto.screenshot), get_floor_bbox)
 
         for i in range(5):
             auto.take_screenshot(gray=False)
-            sc2 = ImageUtils.crop(np.array(auto.screenshot), get_floor_bbox)
-            diff = cv2.absdiff(sc, sc2)
+            current_crop = ImageUtils.crop(np.array(auto.screenshot), get_floor_bbox)
+            diff = cv2.absdiff(previous_crop, current_crop)
             diff_gray = cv2.cvtColor(diff, cv2.COLOR_BGR2GRAY)
-            _, img = cv2.threshold(diff_gray, 5, 255, cv2.THRESH_BINARY)
-            img = cv2.resize(img, None, fx=3.0, fy=3.0, interpolation=cv2.INTER_CUBIC)
-            if handle_ocr(img) and self.floor != this_floor:
+            _, binary_img = cv2.threshold(diff_gray, 5, 255, cv2.THRESH_BINARY)
+            current_scaled = cv2.resize(current_crop, None, fx=2.5, fy=2.5, interpolation=cv2.INTER_CUBIC)
+            binary_img = cv2.resize(binary_img, None, fx=3.0, fy=3.0, interpolation=cv2.INTER_CUBIC)
+
+            floor_found = False
+            for stage_name, candidate_image in (
+                ("current", current_crop),
+                ("current_scaled", current_scaled),
+                ("diff_gray", diff_gray),
+                ("binary", binary_img),
+            ):
+                floor_found, _ = handle_ocr(candidate_image, stage_name)
+                if floor_found:
+                    break
+            previous_crop = current_crop
+            if floor_found and self.floor != this_floor:
                 break
 
         log.debug(f"识别前楼层为{this_floor}，识别后为{self.floor}")


### PR DESCRIPTION
修复原本楼层识别过分依赖单一信源的问题，修改后优先截图放大识别，识别失败后依旧会落回原版差图识别。更新后识图逻辑为：
`current -> current_scaled -> diff_gray -> binary`  
此改动在零协汉化和英语情况且分辨率为1080P时均能正常识别：
```
[DEBUG] 2026-04-10 10:41:37,551 [AALC] module\ocr\ocr.py:49: OCR识别结果：('正在探索第1层',)
[DEBUG] 2026-04-10 10:41:37,552 [AALC] tasks\mirror\mirror.py:1391: 对于楼层信息OCR[current]得到：正在探索第1层
[DEBUG] 2026-04-10 10:41:37,552 [AALC] tasks\mirror\mirror.py:1428: 识别前楼层为0，识别后为1
……
[DEBUG] 2026-04-10 10:45:04,854 [AALC] module\ocr\ocr.py:49: OCR识别结果：('Explo', 'loring', 'FIo', '1', 'or')
[DEBUG] 2026-04-10 10:45:05,616 [AALC] module\ocr\ocr.py:49: OCR识别结果：('Explo', 'loring', 'Flo', 'or')
[DEBUG] 2026-04-10 10:45:06,335 [AALC] module\ocr\ocr.py:49: OCR识别结果：None
[DEBUG] 2026-04-10 10:45:07,140 [AALC] module\ocr\ocr.py:49: OCR识别结果：('Exploring ', 'Floor', '1')
[DEBUG] 2026-04-10 10:45:07,141 [AALC] tasks\mirror\mirror.py:1391: 对于楼层信息OCR[binary]得到：Exploring Floor1
[DEBUG] 2026-04-10 10:45:07,141 [AALC] tasks\mirror\mirror.py:1428: 识别前楼层为0，识别后为1
```
