### PR TITLE
添加锁屏操作和运行时防息屏功能

### DIFF
--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -970,17 +970,20 @@ class AutoDailyView(FlyoutViewBase):
             "autodaily_sleep",
             "autodaily_hibernate",
             "autodaily_shutdown",
+            "autodaily_lock",
         ]
         self.box_exit_game = BaseCheckBox("autodaily_exit_game", None, QT_TRANSLATE_NOOP("BaseCheckBox", "退出游戏"))
         self.box_exit_aalc = BaseCheckBox("autodaily_exit_aalc", None, QT_TRANSLATE_NOOP("BaseCheckBox", "退出AALC"))
         self.box_sleep = BaseCheckBox("autodaily_sleep", None, QT_TRANSLATE_NOOP("BaseCheckBox", "睡眠"))
         self.box_hibernate = BaseCheckBox("autodaily_hibernate", None, QT_TRANSLATE_NOOP("BaseCheckBox", "休眠"))
         self.box_shutdown = BaseCheckBox("autodaily_shutdown", None, QT_TRANSLATE_NOOP("BaseCheckBox", "关机"))
+        self.box_lock = BaseCheckBox("autodaily_lock", None, QT_TRANSLATE_NOOP("BaseCheckBox", "锁屏"))
         self.line_2.addWidget(self.box_exit_game)
         self.line_2.addWidget(self.box_exit_aalc)
         self.line_2.addWidget(self.box_sleep)
         self.line_2.addWidget(self.box_hibernate)
         self.line_2.addWidget(self.box_shutdown)
+        self.line_2.addWidget(self.box_lock)
 
         self.line_3_box = QWidget(self)
         self.line_3 = QHBoxLayout(self.line_3_box)
@@ -990,7 +993,7 @@ class AutoDailyView(FlyoutViewBase):
 
         self.line_3.addWidget(self.save_button)
 
-        self.checkboxes = [self.box_sleep, self.box_hibernate, self.box_shutdown]
+        self.checkboxes = [self.box_sleep, self.box_hibernate, self.box_shutdown, self.box_lock]
         for cb in self.checkboxes:
             cb.check_box.clicked.connect(self.__on_checkbox_clicked)
 
@@ -1013,6 +1016,8 @@ class AutoDailyView(FlyoutViewBase):
             self.config_name = self.__search_parent_class().config_name
         self.setting = cfg.get_value(self.config_name + "_task")
         self.exit_setting = cfg.get_value(self.config_name + "_task_exit")
+        if len(self.exit_setting) < 6:
+            self.exit_setting = list(self.exit_setting) + [False] * (6 - len(self.exit_setting))
 
         task = [
             self.box_daily,
@@ -1028,6 +1033,7 @@ class AutoDailyView(FlyoutViewBase):
             self.box_sleep,
             self.box_hibernate,
             self.box_shutdown,
+            self.box_lock,
         ]
         for i in range(len(exit_task)):
             exit_task[i].set_checked(self.exit_setting[i])
@@ -1050,6 +1056,8 @@ class AutoDailyView(FlyoutViewBase):
             self.exit_setting[index] = not self.exit_setting[index]
 
     def __save(self):
+        if len(self.exit_setting) < 6:
+            self.exit_setting = list(self.exit_setting) + [False] * (6 - len(self.exit_setting))
         cfg.set_value(self.config_name + "_task", self.setting)
         cfg.set_value(self.config_name + "_task_exit", self.exit_setting)
 
@@ -1075,6 +1083,7 @@ class AutoDailyView(FlyoutViewBase):
         self.box_sleep.retranslateUi()
         self.box_hibernate.retranslateUi()
         self.box_shutdown.retranslateUi()
+        self.box_lock.retranslateUi()
 
 
 class DailySettingCard(SwitchSettingCard):

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -200,8 +200,7 @@ class AfterCompletionSelector(QFrame):
         self.setToolTip(self.tr(self._tool_tip_text))
 
         if cfg.keep_after_completion is False:
-            cfg.unsaved_set_value("after_completion_actions", [])
-            cfg.unsaved_set_value("after_completion_power_action", POWER_ACTION_NONE)
+            self._set_after_completion_config([], POWER_ACTION_NONE, False)
 
         self.edit_button.clicked.connect(self._show_editor)
         self.refresh_from_config()

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -200,7 +200,7 @@ class AfterCompletionSelector(QFrame):
         self.setToolTip(self.tr(self._tool_tip_text))
 
         if cfg.keep_after_completion is False:
-            self._set_after_completion_config([], POWER_ACTION_NONE, False)
+            self._set_after_completion_config([], POWER_ACTION_NONE, persist=False)
 
         self.edit_button.clicked.connect(self._show_editor)
         self.refresh_from_config()
@@ -281,14 +281,14 @@ class AfterCompletionSelector(QFrame):
 
     def apply_selection(self, actions: list[str], power_action: str, permanent: bool):
         cfg.unsaved_set_value("keep_after_completion", permanent)
-        self._set_after_completion_config(actions, power_action, permanent)
+        self._set_after_completion_config(actions, power_action, persist=permanent)
         self.refresh_from_config()
         self._close_dialog()
 
     def set_from_external(self, actions: list[str], power_action: str):
         # 命令行/定时注入视为一次性设置，不覆盖用户默认偏好
         cfg.unsaved_set_value("keep_after_completion", False)
-        self._set_after_completion_config(actions, power_action, False)
+        self._set_after_completion_config(actions, power_action, persist=False)
         self.refresh_from_config()
         self._close_dialog()
 

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -30,10 +30,7 @@ from app.page_card import (
 )
 from app.team_setting_card import TeamSettingCard
 from module.automation import auto
-from module.game_and_screen import screen
-from module.hotkey_listener import ExactGlobalHotKeys
-from module.logger import log, ui_log_dispatcher
-from module.system_actions import (
+from module.after_completion_types import (
     ACTION_EXIT_AALC,
     ACTION_EXIT_EMULATOR,
     ACTION_EXIT_GAME,
@@ -42,6 +39,12 @@ from module.system_actions import (
     POWER_ACTION_NONE,
     POWER_ACTION_SHUTDOWN,
     POWER_ACTION_SLEEP,
+    normalize_after_completion_config,
+)
+from module.game_and_screen import screen
+from module.hotkey_listener import ExactGlobalHotKeys
+from module.logger import log, ui_log_dispatcher
+from module.system_actions import (
     get_after_completion_config,
     set_after_completion_config,
 )
@@ -198,7 +201,7 @@ class AfterCompletionSelector(QFrame):
         self._editor_dialog = None
         self.setToolTip(self.tr(self._tool_tip_text))
 
-        if cfg.keep_after_completion is False:
+        if cfg.get_value("keep_after_completion", False) is False:
             self._set_after_completion_config([], POWER_ACTION_NONE, persist=False)
 
         self.edit_button.clicked.connect(self._show_editor)
@@ -226,7 +229,7 @@ class AfterCompletionSelector(QFrame):
             else:
                 display_text = self.tr(self._do_nothing_text)
 
-        mode = self.tr(self._saved_text if cfg.keep_after_completion else self._once_text)
+        mode = self.tr(self._saved_text if cfg.get_value("keep_after_completion", False) else self._once_text)
         full_text = f"{display_text}（{mode}）"
 
         # 动作较多时用换行压缩宽度，完整内容通过悬浮提示查看
@@ -272,11 +275,13 @@ class AfterCompletionSelector(QFrame):
         dialog.show()
 
     def _set_after_completion_config(self, actions: list[str], power_action: str, persist: bool):
+        # UI 层统一先规范化一次，避免一次性设置把脏值写入配置。
+        normalized_actions, normalized_power = normalize_after_completion_config(actions, power_action)
         if persist:
-            set_after_completion_config(actions, power_action)
+            set_after_completion_config(normalized_actions, normalized_power)
         else:
-            cfg.unsaved_set_value("after_completion_actions", actions)
-            cfg.unsaved_set_value("after_completion_power_action", power_action)
+            cfg.unsaved_set_value("after_completion_actions", normalized_actions)
+            cfg.unsaved_set_value("after_completion_power_action", normalized_power)
 
     def apply_selection(self, actions: list[str], power_action: str, permanent: bool):
         cfg.unsaved_set_value("keep_after_completion", permanent)
@@ -597,7 +602,8 @@ class FarmingInterfaceLeft(QWidget):
             self.create_and_start_script()
         else:
             if cfg.set_reduce_miscontact and cfg.simulator is False:
-                screen.reset_win()
+                # 手动停止时仍需恢复游戏窗口，但这里不再要求抢前台。
+                screen.reset_win(activate=False)
             else:
                 if cfg.simulator_type == 0:
                     from module.automation.input_handlers.simulator.mumu_control import (
@@ -630,6 +636,14 @@ class FarmingInterfaceLeft(QWidget):
             if thread_was_running:
                 auto.clear_img_cache()
             mediator.mirror_bar_kill_signal.emit()
+
+    def _on_script_finished(self):
+        # 自然结束只做 UI 收尾；不要复用“手动停止”入口，否则会重复触发窗口清理。
+        log.debug("脚本自然结束，执行 UI 收尾，不再重复重置游戏窗口")
+        self.link_start_button.set_text("Link Start!")
+        self._enable_setting(self.parent())
+        mediator.refresh_teams_order.emit()
+        mediator.mirror_bar_kill_signal.emit()
 
     def _disable_setting(self, parent):
         for child in parent.children():
@@ -691,7 +705,6 @@ class FarmingInterfaceLeft(QWidget):
             self.my_script.start()
         except Exception as e:
             log.error(f"启动脚本失败: {e}")
-            self._apply_keep_awake_if_needed(False)
             self.link_start_button.set_text("Link Start!")
             self._enable_setting(self.parent())
 
@@ -699,8 +712,6 @@ class FarmingInterfaceLeft(QWidget):
         if self.my_script and self.my_script.isRunning():
             log.debug("正在终止脚本线程...")
             self.my_script.terminate()  # 终止线程
-
-
 
     def my_stop_shortcut(self):
         current_text = self.link_start_button.get_text()
@@ -711,7 +722,8 @@ class FarmingInterfaceLeft(QWidget):
         # 连接所有可能信号
         mediator.link_start.connect(self.my_stop_shortcut)
         mediator.kill_signal.connect(self.stop_AALC)
-        mediator.finished_signal.connect(self.start_and_stop_tasks)
+        # finished_signal 表示线程自然结束，不应再走开始/停止按钮的副作用逻辑。
+        mediator.finished_signal.connect(self._on_script_finished)
 
     def retranslateUi(self):
         self.set_windows.retranslateUi()

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -107,10 +107,7 @@ class AfterCompletionActionEditor(FlyoutViewBase):
         self.button_row.addWidget(self.button_save)
         self.vbox.addLayout(self.button_row)
 
-        self.box_exit_game.setChecked(ACTION_EXIT_GAME in actions)
-        self.box_exit_emulator.setChecked(ACTION_EXIT_EMULATOR in actions)
-        self.box_exit_aalc.setChecked(ACTION_EXIT_AALC in actions)
-        self._set_power_combo(power_action)
+        self.set_state(actions, power_action)
 
         self.button_apply.clicked.connect(lambda: self._apply(False))
         self.button_save.clicked.connect(lambda: self._apply(True))
@@ -199,13 +196,11 @@ class AfterCompletionSelector(QFrame):
         self.hbox.addWidget(self.edit_button)
         self.setMinimumWidth(280)
         self._editor_dialog = None
-        self.setToolTip(self.tr(self._tool_tip_text))
 
         if cfg.get_value("keep_after_completion", False) is False:
             self._set_after_completion_config([], POWER_ACTION_NONE, persist=False)
 
         self.edit_button.clicked.connect(self._show_editor)
-        self.refresh_from_config()
         self.retranslateUi()
 
     def _summary_text(self, actions: list[str], power_action: str) -> tuple[str, str]:

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -1,10 +1,17 @@
 import sys
+from typing import Callable
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QT_TRANSLATE_NOOP, Qt
 from PySide6.QtGui import QTextCursor
-from PySide6.QtWidgets import QApplication, QTextEdit
+from PySide6.QtWidgets import QApplication, QDialog, QTextEdit
 from qfluentwidgets import (
+    BodyLabel,
+    CheckBox,
+    ComboBox,
+    FlyoutViewBase,
     PopUpAniStackedWidget,
+    PrimaryPushButton,
+    PushButton,
     TextEdit,
     TransparentToolButton,
     setCustomStyleSheet,
@@ -26,23 +33,287 @@ from module.automation import auto
 from module.game_and_screen import screen
 from module.hotkey_listener import ExactGlobalHotKeys
 from module.logger import log, ui_log_dispatcher
+from module.system_actions import (
+    ACTION_EXIT_AALC,
+    ACTION_EXIT_EMULATOR,
+    ACTION_EXIT_GAME,
+    POWER_ACTION_HIBERNATE,
+    POWER_ACTION_LOCK,
+    POWER_ACTION_NONE,
+    POWER_ACTION_SHUTDOWN,
+    POWER_ACTION_SLEEP,
+    apply_power_keep_awake,
+    get_after_completion_config,
+    set_after_completion_config,
+)
 from tasks.base.script_task_scheme import my_script_task
 from utils.utils import check_hard_mirror_time
 
 
-class ThenComboBox(BaseComboBox):
-    """添加右键永久保存, 不泛用"""
+class AfterCompletionActionEditor(FlyoutViewBase):
+    def __init__(
+        self,
+        actions: list[str],
+        power_action: str,
+        on_apply: Callable[[list[str], str, bool], None],
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._on_apply = on_apply
+        self._action_text = {
+            ACTION_EXIT_GAME: QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "退出游戏"),
+            ACTION_EXIT_EMULATOR: QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "退出模拟器"),
+            ACTION_EXIT_AALC: QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "退出AALC"),
+        }
+        self._power_items = [
+            (QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "无"), POWER_ACTION_NONE),
+            (QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "睡眠"), POWER_ACTION_SLEEP),
+            (QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "休眠"), POWER_ACTION_HIBERNATE),
+            (QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "锁屏"), POWER_ACTION_LOCK),
+            (QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "关机"), POWER_ACTION_SHUTDOWN),
+        ]
+        self._title_actions = QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "前置动作（可多选）")
+        self._title_power = QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "最终动作（单选）")
+        self._button_apply_once = QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "仅本次生效")
+        self._button_save_default = QT_TRANSLATE_NOOP("AfterCompletionActionEditor", "保存为默认")
 
-    def __init__(self, config_name, combo_box_width=None, parent=None):
-        super().__init__(config_name, combo_box_width, tool_tip_delay=600, parent=parent)
+        self.vbox = QVBoxLayout(self)
+        self.vbox.setSpacing(10)
+        self.vbox.setContentsMargins(18, 14, 18, 14)
 
-    def on_change(self, index):
-        if cfg.get_value(self.config_name) is not None:
-            cfg.unsaved_set_value("keep_after_completion", self.combo_box.right_clicked)
-            cfg.set_value(self.config_name, list(self.items.items())[index][1])
+        self.label_actions = BodyLabel(self._title_actions)
+        self.vbox.addWidget(self.label_actions)
+
+        self.box_exit_game = CheckBox(self._action_text[ACTION_EXIT_GAME], self)
+        self.box_exit_emulator = CheckBox(self._action_text[ACTION_EXIT_EMULATOR], self)
+        self.box_exit_aalc = CheckBox(self._action_text[ACTION_EXIT_AALC], self)
+        self.vbox.addWidget(self.box_exit_game)
+        self.vbox.addWidget(self.box_exit_emulator)
+        self.vbox.addWidget(self.box_exit_aalc)
+
+        self.label_power = BodyLabel(self._title_power)
+        self.vbox.addWidget(self.label_power)
+
+        self.power_combo = ComboBox(self)
+        self.power_combo.addItems([self.tr(text) for text, _ in self._power_items])
+        self.vbox.addWidget(self.power_combo)
+
+        self.button_row = QHBoxLayout()
+        self.button_apply = PushButton(self._button_apply_once, self)
+        self.button_save = PrimaryPushButton(self._button_save_default, self)
+        self.button_row.addWidget(self.button_apply)
+        self.button_row.addWidget(self.button_save)
+        self.vbox.addLayout(self.button_row)
+
+        self.box_exit_game.setChecked(ACTION_EXIT_GAME in actions)
+        self.box_exit_emulator.setChecked(ACTION_EXIT_EMULATOR in actions)
+        self.box_exit_aalc.setChecked(ACTION_EXIT_AALC in actions)
+        self._set_power_combo(power_action)
+
+        self.button_apply.clicked.connect(lambda: self._apply(False))
+        self.button_save.clicked.connect(lambda: self._apply(True))
+        self.retranslateUi()
+
+    def set_state(self, actions: list[str], power_action: str) -> None:
+        self.box_exit_game.setChecked(ACTION_EXIT_GAME in actions)
+        self.box_exit_emulator.setChecked(ACTION_EXIT_EMULATOR in actions)
+        self.box_exit_aalc.setChecked(ACTION_EXIT_AALC in actions)
+        self._set_power_combo(power_action)
+
+    def _set_power_combo(self, power_action: str) -> None:
+        for index, (_, value) in enumerate(self._power_items):
+            if value == power_action:
+                self.power_combo.setCurrentIndex(index)
+                return
+        self.power_combo.setCurrentIndex(0)
+
+    def _collect_actions(self) -> list[str]:
+        actions: list[str] = []
+        if self.box_exit_game.isChecked():
+            actions.append(ACTION_EXIT_GAME)
+        if self.box_exit_emulator.isChecked():
+            actions.append(ACTION_EXIT_EMULATOR)
+        if self.box_exit_aalc.isChecked():
+            actions.append(ACTION_EXIT_AALC)
+        return actions
+
+    def _collect_power_action(self) -> str:
+        idx = max(0, self.power_combo.currentIndex())
+        return self._power_items[idx][1]
+
+    def _apply(self, permanent: bool) -> None:
+        self._on_apply(self._collect_actions(), self._collect_power_action(), permanent)
+
+    def retranslateUi(self):
+        self.label_actions.setText(self.tr(self._title_actions))
+        self.label_power.setText(self.tr(self._title_power))
+        self.box_exit_game.setText(self.tr(self._action_text[ACTION_EXIT_GAME]))
+        self.box_exit_emulator.setText(self.tr(self._action_text[ACTION_EXIT_EMULATOR]))
+        self.box_exit_aalc.setText(self.tr(self._action_text[ACTION_EXIT_AALC]))
+        for index, (text, _) in enumerate(self._power_items):
+            self.power_combo.setItemText(index, self.tr(text))
+        self.button_apply.setText(self.tr(self._button_apply_once))
+        self.button_save.setText(self.tr(self._button_save_default))
+
+
+class AfterCompletionSelector(QFrame):
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self._none_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "无")
+        self._action_text = {
+            ACTION_EXIT_GAME: QT_TRANSLATE_NOOP("AfterCompletionSelector", "退出游戏"),
+            ACTION_EXIT_EMULATOR: QT_TRANSLATE_NOOP("AfterCompletionSelector", "退出模拟器"),
+            ACTION_EXIT_AALC: QT_TRANSLATE_NOOP("AfterCompletionSelector", "退出AALC"),
+        }
+        self._power_text = {
+            POWER_ACTION_NONE: QT_TRANSLATE_NOOP("AfterCompletionSelector", "无"),
+            POWER_ACTION_SLEEP: QT_TRANSLATE_NOOP("AfterCompletionSelector", "睡眠"),
+            POWER_ACTION_HIBERNATE: QT_TRANSLATE_NOOP("AfterCompletionSelector", "休眠"),
+            POWER_ACTION_LOCK: QT_TRANSLATE_NOOP("AfterCompletionSelector", "锁屏"),
+            POWER_ACTION_SHUTDOWN: QT_TRANSLATE_NOOP("AfterCompletionSelector", "关机"),
+        }
+        self._edit_button_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "编辑")
+        self._saved_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "默认")
+        self._once_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "本次")
+        self._exit_prefix_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "退出")
+        self._joiner_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "与")
+        self._after_power_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "后，再{0}")
+        self._power_only_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "执行{0}")
+        self._do_nothing_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "什么也不干")
+
+        self.hbox = QHBoxLayout(self)
+        self.hbox.setContentsMargins(0, 0, 0, 0)
+        self.hbox.setSpacing(8)
+
+        self.summary = BodyLabel("", self)
+        self.summary.setWordWrap(True)
+        self.edit_button = PushButton(self._edit_button_text, self)
+        self.edit_button.setFixedWidth(72)
+
+        self.hbox.addWidget(self.summary, stretch=1)
+        self.hbox.addWidget(self.edit_button)
+        self.setMinimumWidth(280)
+        self._editor_dialog = None
+        self.setToolTip(
+            QT_TRANSLATE_NOOP("AfterCompletionSelector", "支持组合动作：退出目标后再执行电源动作，可选择仅本次或保存默认")
+        )
+
+        if cfg.keep_after_completion is False:
+            set_after_completion_config([], POWER_ACTION_NONE)
+
+        self.edit_button.clicked.connect(self._show_editor)
+        self.refresh_from_config()
+        self.retranslateUi()
+
+    def _summary_text(self, actions: list[str], power_action: str) -> tuple[str, str]:
+        exit_names = [self.tr(self._action_text[action]) for action in actions if action in self._action_text]
+        exit_targets = [
+            name[len(self.tr(self._exit_prefix_text)) :] if name.startswith(self.tr(self._exit_prefix_text)) else name
+            for name in exit_names
+        ]
+        power_text = self.tr(self._power_text.get(power_action, self._none_text))
+
+        if exit_targets:
+            exit_text = self.tr(self._joiner_text).join(exit_targets)
+            exit_clause = f"{self.tr(self._exit_prefix_text)}{exit_text}"
+            if power_action != POWER_ACTION_NONE:
+                display_text = f"{exit_clause}{self.tr(self._after_power_text).format(power_text)}"
+            else:
+                display_text = exit_clause
         else:
-            data_dict = {self.config_name: list(self.items.items())[index][1]}
-            self.send_switch_signal(data_dict)
+            if power_action != POWER_ACTION_NONE:
+                display_text = self.tr(self._power_only_text).format(power_text)
+            else:
+                display_text = self.tr(self._do_nothing_text)
+
+        mode = self.tr(self._saved_text if cfg.keep_after_completion else self._once_text)
+        full_text = f"{display_text}（{mode}）"
+
+        # 动作较多时用换行压缩宽度，完整内容通过悬浮提示查看
+        if len(exit_targets) >= 3 and power_action != POWER_ACTION_NONE:
+            exit_text = self.tr(self._joiner_text).join(exit_targets)
+            display_text = (
+                f"{self.tr(self._exit_prefix_text)}{exit_text}\n"
+                f"{self.tr(self._after_power_text).format(power_text)}"
+            )
+
+        return display_text, full_text
+
+    def _show_editor(self):
+        if self._editor_dialog is not None and self._editor_dialog.isVisible():
+            self._editor_dialog.raise_()
+            self._editor_dialog.activateWindow()
+            return
+
+        # 先刷新摘要，确保界面展示与配置一致
+        self.refresh_from_config()
+        actions, power_action = get_after_completion_config()
+        dialog = QDialog(self.window())
+        dialog.setWindowTitle(self.tr("结束后操作"))
+        dialog.setWindowModality(Qt.WindowModality.WindowModal)
+        dialog.setAttribute(Qt.WA_DeleteOnClose, True)
+        dialog_layout = QVBoxLayout(dialog)
+        dialog_layout.setContentsMargins(12, 12, 12, 12)
+        editor = AfterCompletionActionEditor(
+            actions,
+            power_action,
+            lambda selected_actions, selected_power, permanent: self._apply_from_dialog(
+                selected_actions,
+                selected_power,
+                permanent,
+                dialog,
+            ),
+            dialog,
+        )
+        dialog_layout.addWidget(editor)
+        dialog.resize(360, 280)
+        dialog.finished.connect(lambda _: setattr(self, "_editor_dialog", None))
+        self._editor_dialog = dialog
+        dialog.show()
+
+    def apply_selection(self, actions: list[str], power_action: str, permanent: bool):
+        cfg.unsaved_set_value("keep_after_completion", permanent)
+        set_after_completion_config(actions, power_action)
+        self.refresh_from_config()
+        self._close_dialog()
+
+    def set_from_external(self, actions: list[str], power_action: str):
+        # 命令行/定时注入视为一次性设置，不覆盖用户默认偏好
+        cfg.unsaved_set_value("keep_after_completion", False)
+        set_after_completion_config(actions, power_action)
+        self.refresh_from_config()
+        self._close_dialog()
+
+    def _apply_from_dialog(self, actions: list[str], power_action: str, permanent: bool, dialog: QDialog):
+        self.apply_selection(actions, power_action, permanent)
+        try:
+            dialog.close()
+        except Exception:
+            pass
+
+    def _close_dialog(self):
+        if self._editor_dialog is not None:
+            try:
+                self._editor_dialog.close()
+            except Exception:
+                pass
+            self._editor_dialog = None
+
+    def _hide_editor(self):
+        # 兼容外部调用
+        self._close_dialog()
+
+    def refresh_from_config(self):
+        actions, power_action = get_after_completion_config()
+        summary_text, full_text = self._summary_text(actions, power_action)
+        self.summary.setText(summary_text)
+        self.summary.setToolTip(full_text)
+
+    def retranslateUi(self):
+        self.edit_button.setText(self.tr(self._edit_button_text))
+        self.refresh_from_config()
+        if self.toolTip():
+            self.setToolTip(self.tr(self.toolTip()))
 
 
 class FarmingInterface(QWidget):
@@ -103,6 +374,9 @@ class FarmingInterface(QWidget):
     def my_pause_and_resume(self):
         auto.set_pause()
 
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+
 
 class FarmingInterfaceLeft(QWidget):
     def __init__(self, parent=None):
@@ -111,7 +385,7 @@ class FarmingInterfaceLeft(QWidget):
         self.setObjectName("FarmingInterfaceLeft")
 
         self.my_script = None
-        self.then_info_bar = None
+        self.keep_awake_active = False
 
         self.__init_widget()
         self.__init_card()
@@ -181,14 +455,7 @@ class FarmingInterfaceLeft(QWidget):
 
         self.then = BaseLabel(QT_TRANSLATE_NOOP("BaseLabel", "之后"))
 
-        self.then_combobox = ThenComboBox("after_completion")
-        self.then_combobox.setToolTip(
-            QT_TRANSLATE_NOOP("ThenComboBox", "选择脚本结束后的操作，右键点击并更改选项可永久保存")
-        )
-        self.then_combobox.add_items(set_after_completion_options)
-        self.then_combobox.combo_box.RightClicked.connect(self.then_combobox_right_clicked)
-        if cfg.keep_after_completion is False:
-            self.then_combobox.set_options(0)
+        self.after_completion_selector = AfterCompletionSelector(self)
         self.link_start_button = NormalTextButton("Link Start!", "link_start", 0)
         self.link_start_button.clicked.connect(self.start_and_stop_tasks)
         self.link_start_button.button.setMinimumSize(130, 70)
@@ -216,7 +483,7 @@ class FarmingInterfaceLeft(QWidget):
 
         self.hbox_layout.addWidget(self.setting_box)
         self.hbox_layout.addWidget(self.then)
-        self.hbox_layout.addWidget(self.then_combobox)
+        self.hbox_layout.addWidget(self.after_completion_selector)
         self.hbox_layout.addWidget(self.link_start_button)
 
     @staticmethod
@@ -231,6 +498,11 @@ class FarmingInterfaceLeft(QWidget):
 
     def stop_AALC(self):
         log.debug("即将关闭AALC")
+        try:
+            self.after_completion_selector._hide_editor()
+        except Exception:
+            pass
+        self._apply_keep_awake_if_needed(False)
         sys.exit(0)
 
     def check_setting(self):
@@ -315,6 +587,7 @@ class FarmingInterfaceLeft(QWidget):
             # 启动前检查设置，防呆
             if self.check_setting() is False:
                 return
+            self._apply_keep_awake_if_needed(True)
             self.link_start_button.set_text("S t o p !")
             self._disable_setting(self.parent())
             self.create_and_start_script()
@@ -331,7 +604,7 @@ class FarmingInterfaceLeft(QWidget):
                         try:
                             MumuControl.clean_connect()
                             break
-                        except:
+                        except Exception:
                             continue
                 else:
                     from module.automation.input_handlers.simulator.simulator_control import (
@@ -342,13 +615,17 @@ class FarmingInterfaceLeft(QWidget):
                         try:
                             SimulatorControl.clean_connect()
                             break
-                        except:
+                        except Exception:
                             continue
             self.link_start_button.set_text("Link Start!")
             self._enable_setting(self.parent())
             mediator.refresh_teams_order.emit()
+            # 检查线程是否仍在运行，如果仍在运行则执行清理，否则跳过（因为脚本已自行清理）
+            thread_was_running = self.my_script is not None and self.my_script.isRunning()
             self.stop_script()
-            auto.clear_img_cache()
+            if thread_was_running:
+                auto.clear_img_cache()
+                self._apply_keep_awake_if_needed(False)
             mediator.mirror_bar_kill_signal.emit()
 
     def _disable_setting(self, parent):
@@ -399,20 +676,6 @@ class FarmingInterfaceLeft(QWidget):
                 # 递归处理子部件的子部件（如布局中的嵌套控件）
                 self._enable_setting(child)
 
-    def then_combobox_right_clicked(self):
-        if self.then_info_bar is not None:
-            return
-        self.then_info_bar = BaseInfoBar.info(
-            title=self.tr("当前选择后会永久保存"),
-            content="",
-            orient=Qt.Horizontal,
-            isClosable=True,
-            position=InfoBarPosition.BOTTOM_LEFT,
-            duration=1500,
-            parent=self.window(),
-        )
-        self.then_info_bar.destroyed.connect(lambda: setattr(self, "then_info_bar", None))
-
     def create_and_start_script(self):
         try:
             msg = "开始进行所有任务"
@@ -425,11 +688,24 @@ class FarmingInterfaceLeft(QWidget):
             self.my_script.start()
         except Exception as e:
             log.error(f"启动脚本失败: {e}")
+            self._apply_keep_awake_if_needed(False)
+            self.link_start_button.set_text("Link Start!")
+            self._enable_setting(self.parent())
 
     def stop_script(self):
         if self.my_script and self.my_script.isRunning():
             log.debug("正在终止脚本线程...")
             self.my_script.terminate()  # 终止线程
+
+    def _apply_keep_awake_if_needed(self, enable: bool):
+        if not bool(getattr(cfg, "experimental_keep_screen_awake", False)):
+            return
+        if enable and not self.keep_awake_active:
+            apply_power_keep_awake(True)
+            self.keep_awake_active = True
+        elif not enable and self.keep_awake_active:
+            apply_power_keep_awake(False)
+            self.keep_awake_active = False
 
     def my_stop_shortcut(self):
         current_text = self.link_start_button.get_text()
@@ -451,7 +727,7 @@ class FarmingInterfaceLeft(QWidget):
         self.resonate_with_Ahab.retranslateUi()
 
         self.then.retranslateUi()
-        self.then_combobox.retranslateUi()
+        self.after_completion_selector.retranslateUi()
         self.select_all.retranslateUi()
         self.clear_all.retranslateUi()
 

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -180,6 +180,9 @@ class AfterCompletionSelector(QFrame):
         self._after_power_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "后，再{0}")
         self._power_only_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "执行{0}")
         self._do_nothing_text = QT_TRANSLATE_NOOP("AfterCompletionSelector", "什么也不干")
+        self._tool_tip_text = QT_TRANSLATE_NOOP(
+            "AfterCompletionSelector", "支持组合动作：退出目标后再执行电源动作，可选择仅本次或保存默认"
+        )
 
         self.hbox = QHBoxLayout(self)
         self.hbox.setContentsMargins(0, 0, 0, 0)
@@ -194,12 +197,11 @@ class AfterCompletionSelector(QFrame):
         self.hbox.addWidget(self.edit_button)
         self.setMinimumWidth(280)
         self._editor_dialog = None
-        self.setToolTip(
-            QT_TRANSLATE_NOOP("AfterCompletionSelector", "支持组合动作：退出目标后再执行电源动作，可选择仅本次或保存默认")
-        )
+        self.setToolTip(self.tr(self._tool_tip_text))
 
         if cfg.keep_after_completion is False:
-            set_after_completion_config([], POWER_ACTION_NONE)
+            cfg.unsaved_set_value("after_completion_actions", [])
+            cfg.unsaved_set_value("after_completion_power_action", POWER_ACTION_NONE)
 
         self.edit_button.clicked.connect(self._show_editor)
         self.refresh_from_config()
@@ -271,16 +273,23 @@ class AfterCompletionSelector(QFrame):
         self._editor_dialog = dialog
         dialog.show()
 
+    def _set_after_completion_config(self, actions: list[str], power_action: str, persist: bool):
+        if persist:
+            set_after_completion_config(actions, power_action)
+        else:
+            cfg.unsaved_set_value("after_completion_actions", actions)
+            cfg.unsaved_set_value("after_completion_power_action", power_action)
+
     def apply_selection(self, actions: list[str], power_action: str, permanent: bool):
         cfg.unsaved_set_value("keep_after_completion", permanent)
-        set_after_completion_config(actions, power_action)
+        self._set_after_completion_config(actions, power_action, permanent)
         self.refresh_from_config()
         self._close_dialog()
 
     def set_from_external(self, actions: list[str], power_action: str):
         # 命令行/定时注入视为一次性设置，不覆盖用户默认偏好
         cfg.unsaved_set_value("keep_after_completion", False)
-        set_after_completion_config(actions, power_action)
+        self._set_after_completion_config(actions, power_action, False)
         self.refresh_from_config()
         self._close_dialog()
 
@@ -312,8 +321,8 @@ class AfterCompletionSelector(QFrame):
     def retranslateUi(self):
         self.edit_button.setText(self.tr(self._edit_button_text))
         self.refresh_from_config()
-        if self.toolTip():
-            self.setToolTip(self.tr(self.toolTip()))
+        if self._tool_tip_text:
+            self.setToolTip(self.tr(self._tool_tip_text))
 
 
 class FarmingInterface(QWidget):

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -42,7 +42,6 @@ from module.system_actions import (
     POWER_ACTION_NONE,
     POWER_ACTION_SHUTDOWN,
     POWER_ACTION_SLEEP,
-    apply_power_keep_awake,
     get_after_completion_config,
     set_after_completion_config,
 )
@@ -393,7 +392,6 @@ class FarmingInterfaceLeft(QWidget):
         self.setObjectName("FarmingInterfaceLeft")
 
         self.my_script = None
-        self.keep_awake_active = False
 
         self.__init_widget()
         self.__init_card()
@@ -510,7 +508,6 @@ class FarmingInterfaceLeft(QWidget):
             self.after_completion_selector._hide_editor()
         except Exception:
             pass
-        self._apply_keep_awake_if_needed(False)
         sys.exit(0)
 
     def check_setting(self):
@@ -595,7 +592,6 @@ class FarmingInterfaceLeft(QWidget):
             # 启动前检查设置，防呆
             if self.check_setting() is False:
                 return
-            self._apply_keep_awake_if_needed(True)
             self.link_start_button.set_text("S t o p !")
             self._disable_setting(self.parent())
             self.create_and_start_script()
@@ -633,7 +629,6 @@ class FarmingInterfaceLeft(QWidget):
             self.stop_script()
             if thread_was_running:
                 auto.clear_img_cache()
-                self._apply_keep_awake_if_needed(False)
             mediator.mirror_bar_kill_signal.emit()
 
     def _disable_setting(self, parent):
@@ -705,15 +700,7 @@ class FarmingInterfaceLeft(QWidget):
             log.debug("正在终止脚本线程...")
             self.my_script.terminate()  # 终止线程
 
-    def _apply_keep_awake_if_needed(self, enable: bool):
-        if not bool(getattr(cfg, "experimental_keep_screen_awake", False)):
-            return
-        if enable and not self.keep_awake_active:
-            apply_power_keep_awake(True)
-            self.keep_awake_active = True
-        elif not enable and self.keep_awake_active:
-            apply_power_keep_awake(False)
-            self.keep_awake_active = False
+
 
     def my_stop_shortcut(self):
         current_text = self.link_start_button.get_text()

--- a/app/mediator.py
+++ b/app/mediator.py
@@ -18,6 +18,8 @@ class Mediator(QObject):
     warning = Signal(str)
     finished_signal = Signal()
     kill_signal = Signal()
+    # 任务线程通过信号请求主窗口抢回前台，避免跨层直接操作 UI。
+    request_focus = Signal()
     mirror_signal = Signal(int, int)  # 运行的当前次数和总次数
     mirror_bar_kill_signal = Signal()
     hotkey_listener_stop_signal = Signal()

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -49,6 +49,7 @@ from module.config import cfg
 from module.font_manager import font_manager
 from module.logger import log
 from module.system_actions import (
+    LEGACY_AFTER_COMPLETION_TO_CONFIG,
     POWER_ACTION_NONE,
     autodaily_exit_to_after_completion_config,
 )
@@ -362,18 +363,7 @@ class MainWindow(FramelessWindow):
                 actions, power_action = parsed_actions, parsed_power_action
             else:
                 # 兼容旧命令行数字参数
-                legacy_map = {
-                    0: ([], POWER_ACTION_NONE),
-                    1: ([], "sleep"),
-                    2: ([], "hibernate"),
-                    3: ([], "shutdown"),
-                    4: (["exit_game"], POWER_ACTION_NONE),
-                    5: (["exit_aalc"], POWER_ACTION_NONE),
-                    6: (["exit_game", "exit_aalc"], POWER_ACTION_NONE),
-                    7: (["exit_emulator"], POWER_ACTION_NONE),
-                    8: (["exit_emulator", "exit_aalc"], POWER_ACTION_NONE),
-                }
-                actions, power_action = legacy_map.get(exit_type, ([], POWER_ACTION_NONE))
+                actions, power_action = LEGACY_AFTER_COMPLETION_TO_CONFIG.get(exit_type, ([], POWER_ACTION_NONE))
             self.farming_interface.interface_left.after_completion_selector.set_from_external(actions, power_action)
 
         if start_flag:

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -1,3 +1,4 @@
+import ctypes
 import os
 import re
 import subprocess
@@ -46,14 +47,20 @@ from app.setting_interface import SettingInterface
 from app.team_setting_card import TeamSettingCard
 from app.tools_interface import ToolsInterface
 from module.config import cfg
+from module.after_completion_types import (
+    LEGACY_AFTER_COMPLETION_TO_CONFIG,
+    POWER_ACTION_NONE,
+    normalize_after_completion_config,
+)
 from module.font_manager import font_manager
 from module.logger import log
 from module.system_actions import (
-    LEGACY_AFTER_COMPLETION_TO_CONFIG,
-    POWER_ACTION_NONE,
     autodaily_exit_to_after_completion_config,
 )
 from module.update.check_update import check_update
+
+# WinRT toast / Win32 焦点切换存在异步回跳，这里保留一次延迟补偿。
+_FOREGROUND_RETRY_DELAY_MS = 600
 
 
 class Language(Enum):
@@ -363,7 +370,9 @@ class MainWindow(FramelessWindow):
                 actions, power_action = parsed_actions, parsed_power_action
             else:
                 # 兼容旧命令行数字参数
-                actions, power_action = LEGACY_AFTER_COMPLETION_TO_CONFIG.get(exit_type, ([], POWER_ACTION_NONE))
+                actions, power_action = normalize_after_completion_config(
+                    *LEGACY_AFTER_COMPLETION_TO_CONFIG.get(exit_type, ((), POWER_ACTION_NONE))
+                )
             self.farming_interface.interface_left.after_completion_selector.set_from_external(actions, power_action)
 
         if start_flag:
@@ -510,6 +519,47 @@ class MainWindow(FramelessWindow):
         mediator.update_progress.connect(self.set_progress_ring)
         mediator.download_complete.connect(self.download_and_install)
         mediator.warning.connect(self.show_warning)
+        # 由任务线程发起请求、由主窗口执行前台切换，避免执行层直接耦合 UI。
+        mediator.request_focus.connect(self._force_foreground)
+
+    def _force_foreground(self) -> None:
+        """强制将 AALC 主窗口拉至前台，绕过 Windows 焦点保护。
+        执行两次（立即 + 延迟补偿），覆盖 WinRT toast 通知在异步阶段归还焦点的行为。
+        """
+        self._do_force_foreground()
+        QTimer.singleShot(_FOREGROUND_RETRY_DELAY_MS, self._do_force_foreground)
+
+    def _do_force_foreground(self) -> None:
+        if os.name != "nt":
+            return
+        if not self.isVisible():
+            self.showNormal()
+        hwnd = int(self.winId())
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+        hwnd_fg = user32.GetForegroundWindow()
+        if hwnd_fg == 0:
+            log.debug("未获取到当前前台窗口，跳过本次焦点切换")
+            return
+        if hwnd_fg == hwnd:
+            return
+        thread_fg = user32.GetWindowThreadProcessId(hwnd_fg, None)
+        if thread_fg == 0:
+            log.debug("未获取到前台线程，跳过本次焦点切换")
+            return
+        thread_cur = kernel32.GetCurrentThreadId()
+        attached = thread_fg != thread_cur
+        if attached:
+            # 借用当前前台线程的输入队列权限，降低 SetForegroundWindow 被系统忽略的概率。
+            user32.AttachThreadInput(thread_fg, thread_cur, True)
+        try:
+            user32.BringWindowToTop(hwnd)
+            user32.SetForegroundWindow(hwnd)
+        finally:
+            if attached:
+                user32.AttachThreadInput(thread_fg, thread_cur, False)
+        self.raise_()
+        self.activateWindow()
 
     def set_ring(self):
         self.progress_ring.raise_()  # 保持最上层显示

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -48,6 +48,10 @@ from app.tools_interface import ToolsInterface
 from module.config import cfg
 from module.font_manager import font_manager
 from module.logger import log
+from module.system_actions import (
+    POWER_ACTION_NONE,
+    autodaily_exit_to_after_completion_config,
+)
 from module.update.check_update import check_update
 
 
@@ -292,6 +296,8 @@ class MainWindow(FramelessWindow):
         start_flag = False
         exit_flag = False
         exit_type = 0
+        parsed_actions = None
+        parsed_power_action = None
         last_cmd = ""
         # 读取输入参数
         for index, arg in enumerate(argv):
@@ -314,20 +320,10 @@ class MainWindow(FramelessWindow):
                 try:
                     if isinstance(argv[index + 1], str) and argv[index + 1].startswith("autodaily"):
                         exit_task = cfg.get_value(argv[index + 1] + "_task_exit")
-                        if exit_task[4]:
-                            exit_type = 3
-                        elif exit_task[3]:
-                            exit_type = 2
-                        elif exit_task[2]:
-                            exit_type = 1
-                        elif exit_task[0] and exit_task[1]:
-                            exit_type = 6
-                        elif exit_task[1]:
-                            exit_type = 5
-                        elif exit_task[0]:
-                            exit_type = 4
-                        else:
-                            exit_type = 0
+                        actions, power_action = autodaily_exit_to_after_completion_config(exit_task)
+                        parsed_actions = actions
+                        parsed_power_action = power_action
+                        exit_type = 0
                         autodaily_task = cfg.get_value(argv[index + 1] + "_task")
                         if autodaily_task[0]:
                             self.farming_interface.interface_left.daily_task.box.set_check_true()
@@ -347,7 +343,7 @@ class MainWindow(FramelessWindow):
                             self.farming_interface.interface_left.mirror.box.set_check_false()
                     else:
                         exit_type = int(argv[index + 1])
-                        if exit_type < 0 or exit_type > 6:
+                        if exit_type < 0 or exit_type > 8:
                             exit_type = 0
                             log.error(f'命令行参数 --exit 后输入值"{argv[index + 1]}"越界')
                 except (IndexError, ValueError):
@@ -362,7 +358,23 @@ class MainWindow(FramelessWindow):
 
         # 最终执行操作
         if exit_flag:
-            self.farming_interface.interface_left.then_combobox.combo_box.setCurrentIndex(exit_type)
+            if parsed_actions is not None and parsed_power_action is not None:
+                actions, power_action = parsed_actions, parsed_power_action
+            else:
+                # 兼容旧命令行数字参数
+                legacy_map = {
+                    0: ([], POWER_ACTION_NONE),
+                    1: ([], "sleep"),
+                    2: ([], "hibernate"),
+                    3: ([], "shutdown"),
+                    4: (["exit_game"], POWER_ACTION_NONE),
+                    5: (["exit_aalc"], POWER_ACTION_NONE),
+                    6: (["exit_game", "exit_aalc"], POWER_ACTION_NONE),
+                    7: (["exit_emulator"], POWER_ACTION_NONE),
+                    8: (["exit_emulator", "exit_aalc"], POWER_ACTION_NONE),
+                }
+                actions, power_action = legacy_map.get(exit_type, ([], POWER_ACTION_NONE))
+            self.farming_interface.interface_left.after_completion_selector.set_from_external(actions, power_action)
 
         if start_flag:
             log.info("开始通过命令行参数启动程序")
@@ -385,6 +397,10 @@ class MainWindow(FramelessWindow):
             self.titleBar.closeBtn.setHoverColor(Qt.white)
 
     def closeEvent(self, e):
+        try:
+            self.farming_interface.interface_left._apply_keep_awake_if_needed(False)
+        except Exception:
+            pass
         # 保存窗口位置
         cfg.set_value("window_position_x", self.x())
         cfg.set_value("window_position_y", self.y())

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -387,10 +387,6 @@ class MainWindow(FramelessWindow):
             self.titleBar.closeBtn.setHoverColor(Qt.white)
 
     def closeEvent(self, e):
-        try:
-            self.farming_interface.interface_left._apply_keep_awake_if_needed(False)
-        except Exception:
-            pass
         # 保存窗口位置
         cfg.set_value("window_position_x", self.x())
         cfg.set_value("window_position_y", self.y())

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -396,6 +396,17 @@ class SettingInterface(QWidget):
             config_name="experimental_auto_lang",
             parent=self.experimental_group,
         )
+        self.keep_screen_awake_card = SwitchSettingCard(
+            FIF.VIEW,
+            QT_TRANSLATE_NOOP("SwitchSettingCard", "运行时保持屏幕唤醒"),
+            QT_TRANSLATE_NOOP(
+                "SwitchSettingCard",
+                "任务运行中阻止系统休眠与锁屏；任务结束、停止或异常退出后会自动恢复系统默认策略",
+            ),
+            config_name="experimental_keep_screen_awake",
+            parent=self.experimental_group,
+        )
+
 
     def _on_hard_mirror_chance_confirm(self, _: int) -> None:
         """手动调整困难模式次数后，同步刷新自动切换时间戳。"""
@@ -446,6 +457,8 @@ class SettingInterface(QWidget):
         self.about_group.addSettingCard(self.feedback_card)
 
         self.experimental_group.addSettingCard(self.auto_lang_card)
+        self.experimental_group.addSettingCard(self.keep_screen_awake_card)
+
 
         self.expand_layout.addWidget(self.game_setting_group)
         self.expand_layout.addWidget(self.theme_pack_group)
@@ -677,6 +690,8 @@ class SettingInterface(QWidget):
         self.feedback_card.retranslateUi()
         self.experimental_group.retranslateUi()
         self.auto_lang_card.retranslateUi()
+        self.keep_screen_awake_card.retranslateUi()
+
 
     def __onThemeCardChanged(self):
         theme_mode = cfg.get_value("theme_mode")

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -33,21 +33,23 @@ theme_mode: AUTO # 应用主题：AUTO, LIGHT, DARK
 autostart: False # 自启动
 autodaily: False # 启用定时执行
 autodaily_task: [False, False, False, False]
-autodaily_task_exit: [False, False, False, False,False]
+autodaily_task_exit: [False, False, False, False, False, False]
 autodaily_time: "00:00" # 定时执行时间 (HH:mm)
 autodaily2: False # 启用定时执行2
 autodaily2_task: [False, False, False, False]
-autodaily2_task_exit: [False, False, False, False,False]
+autodaily2_task_exit: [False, False, False, False, False, False]
 autodaily_time2: "00:00" # 定时执行时间2 (HH:mm)
 autodaily3: False # 启用定时执行3
 autodaily3_task: [False, False, False, False]
-autodaily3_task_exit: [False, False, False, False,False]
+autodaily3_task_exit: [False, False, False, False, False, False]
 autodaily_time3: "00:00" # 定时执行时间3 (HH:mm)
 autodaily4: False # 启用定时执行4
 autodaily4_task: [False, False, False, False]
-autodaily4_task_exit: [False, False, False, False,False]
+autodaily4_task_exit: [False, False, False, False, False, False]
 autodaily_time4: "00:00" # 定时执行时间4 (HH:mm)
 minimize_to_tray: False # 最小化到托盘
+after_completion_actions: [] # 脚本结束后的前置动作（可多选）：exit_game/exit_emulator/exit_aalc
+after_completion_power_action: "none" # 脚本结束后的最终动作（单选）：none/sleep/hibernate/lock/shutdown
 
 # 脚本运行速度设置
 screenshot_interval: 0.85 # 截图间隔时间
@@ -57,6 +59,8 @@ resonate_with_Ahab: False # 是否播放亚哈语录
 
 # 实验性功能
 experimental_auto_lang: True # 是否自动修改语言
+experimental_keep_screen_awake: False # 运行期间阻止系统与显示器休眠，任务结束自动恢复
+
 
 
 # 模拟器设置

--- a/module/after_completion_types.py
+++ b/module/after_completion_types.py
@@ -1,0 +1,133 @@
+"""结束后动作系统的类型与兼容常量。
+
+内部可以使用 Enum/Flag 表达语义，配置层仍统一落为字符串协议。
+"""
+
+from collections.abc import Iterable
+from enum import IntFlag, StrEnum
+
+
+class ExitAction(StrEnum):
+    EXIT_GAME = "exit_game"
+    EXIT_EMULATOR = "exit_emulator"
+    EXIT_AALC = "exit_aalc"
+
+
+class ExitActionFlag(IntFlag):
+    NONE = 0
+    EXIT_GAME = 1
+    EXIT_EMULATOR = 2
+    EXIT_AALC = 4
+
+
+class PowerAction(StrEnum):
+    NONE = "none"
+    SLEEP = "sleep"
+    HIBERNATE = "hibernate"
+    SHUTDOWN = "shutdown"
+    LOCK = "lock"
+
+
+ACTION_EXIT_GAME = ExitAction.EXIT_GAME
+ACTION_EXIT_EMULATOR = ExitAction.EXIT_EMULATOR
+ACTION_EXIT_AALC = ExitAction.EXIT_AALC
+
+POWER_ACTION_NONE = PowerAction.NONE
+POWER_ACTION_SLEEP = PowerAction.SLEEP
+POWER_ACTION_HIBERNATE = PowerAction.HIBERNATE
+POWER_ACTION_SHUTDOWN = PowerAction.SHUTDOWN
+POWER_ACTION_LOCK = PowerAction.LOCK
+
+AFTER_ACTIONS_ORDER: tuple[ExitAction, ...] = (
+    ACTION_EXIT_GAME,
+    ACTION_EXIT_EMULATOR,
+    ACTION_EXIT_AALC,
+)
+
+POWER_ACTIONS: tuple[PowerAction, ...] = (
+    POWER_ACTION_NONE,
+    POWER_ACTION_SLEEP,
+    POWER_ACTION_HIBERNATE,
+    POWER_ACTION_SHUTDOWN,
+    POWER_ACTION_LOCK,
+)
+
+_EXIT_ACTION_TO_FLAG: dict[ExitAction, ExitActionFlag] = {
+    ACTION_EXIT_GAME: ExitActionFlag.EXIT_GAME,
+    ACTION_EXIT_EMULATOR: ExitActionFlag.EXIT_EMULATOR,
+    ACTION_EXIT_AALC: ExitActionFlag.EXIT_AALC,
+}
+
+# 引入版本：v1772205660 (PR #593)
+# 旧数字配置的兼容映射集中维护在这里，避免业务层各自复制一份协议。
+LEGACY_AFTER_COMPLETION_TO_CONFIG: dict[int, tuple[tuple[ExitAction, ...], PowerAction]] = {
+    0: ((), POWER_ACTION_NONE),
+    1: ((), POWER_ACTION_SLEEP),
+    2: ((), POWER_ACTION_HIBERNATE),
+    3: ((), POWER_ACTION_SHUTDOWN),
+    4: ((ACTION_EXIT_GAME,), POWER_ACTION_NONE),
+    5: ((ACTION_EXIT_AALC,), POWER_ACTION_NONE),
+    6: ((ACTION_EXIT_GAME, ACTION_EXIT_AALC), POWER_ACTION_NONE),
+    7: ((ACTION_EXIT_EMULATOR,), POWER_ACTION_NONE),
+    8: ((ACTION_EXIT_EMULATOR, ACTION_EXIT_AALC), POWER_ACTION_NONE),
+}
+
+
+def parse_exit_action(value: str | ExitAction | None) -> ExitAction | None:
+    if isinstance(value, ExitAction):
+        return value
+    if isinstance(value, str):
+        try:
+            return ExitAction(value)
+        except ValueError:
+            return None
+    return None
+
+
+def build_exit_action_flag(
+    actions: Iterable[str | ExitAction] | str | ExitAction | None,
+) -> ExitActionFlag:
+    if actions is None:
+        return ExitActionFlag.NONE
+
+    candidates = [actions] if isinstance(actions, str) else actions
+    flags = ExitActionFlag.NONE
+    for raw_action in candidates:
+        action = parse_exit_action(raw_action)
+        if action is not None:
+            flags |= _EXIT_ACTION_TO_FLAG[action]
+    return flags
+
+
+def normalize_after_actions(
+    actions: Iterable[str | ExitAction] | str | ExitAction | None,
+) -> list[ExitAction]:
+    flags = build_exit_action_flag(actions)
+    return [action for action in AFTER_ACTIONS_ORDER if flags & _EXIT_ACTION_TO_FLAG[action]]
+
+
+def serialize_after_actions(actions: Iterable[str | ExitAction] | str | ExitAction | None) -> list[str]:
+    return [action.value for action in normalize_after_actions(actions)]
+
+
+def normalize_power_action(action: str | PowerAction | None) -> PowerAction:
+    if isinstance(action, PowerAction):
+        return action
+    if isinstance(action, str):
+        try:
+            return PowerAction(action)
+        except ValueError:
+            return POWER_ACTION_NONE
+    return POWER_ACTION_NONE
+
+
+def serialize_power_action(action: str | PowerAction | None) -> str:
+    return normalize_power_action(action).value
+
+
+def normalize_after_completion_config(
+    actions: Iterable[str | ExitAction] | str | ExitAction | None,
+    power_action: str | PowerAction | None,
+) -> tuple[list[str], str]:
+    # 对外统一返回可持久化的字符串结构，避免把 Enum 直接写入配置。
+    return serialize_after_actions(actions), serialize_power_action(power_action)

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -272,6 +272,7 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
             self.set_mouse_pos(x, y)
             self.set_active()
             self.mouse_down(x, y)
+            sleep(0.03)
             self.mouse_up(x, y)
             # 多次点击执行很快所以暂停放到循环外
 
@@ -298,8 +299,9 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
         self.set_active()
         self.set_mouse_pos(x, y)
         self.mouse_down(x, y)
-        self.set_mouse_pos(x, y + int(300 * scale * reverse), duration=0.4)
-        self.mouse_up(x, y)
+        end_y = y + int(300 * scale * reverse)
+        self.set_mouse_pos(x, end_y, duration=0.4)
+        self.mouse_up(x, end_y)
 
         if move_back and current_mouse_position:
             self.mouse_move(current_mouse_position)
@@ -324,7 +326,7 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
             sleep(drag_time * 0.3)
         else:
             sleep(0.5)
-        self.mouse_up(x, y)
+        self.mouse_up(x + dx, y + dy)
 
         if move_back and current_mouse_position:
             self.mouse_move(current_mouse_position)
@@ -361,6 +363,7 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
             self.set_mouse_pos(x, y)
             self.set_active()
             self.mouse_down(x, y)
+            sleep(0.03)
             self.mouse_up(x, y)
 
         if move_back and current_mouse_position:
@@ -558,7 +561,7 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
             sleep(drag_time * 0.3)
         else:
             sleep(0.5)
-        self.mouse_up(x, y)
+        self.mouse_up(x + dx, y + dy)
         screen.handle.set_window_pos(*pos)
 
     def mouse_drag_down(self, x, y, reverse=1, move_back=True) -> None:
@@ -566,8 +569,9 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         self.set_active()
         pos = self._set_window_pos(x, y)
         self.mouse_down(x, y)
-        self._window_move_to(x, y + int(500 * scale * reverse), duration=0.6)
-        self.mouse_up(x, y)
+        end_y = y + int(500 * scale * reverse)
+        self._window_move_to(x, end_y, duration=0.6)
+        self.mouse_up(x, end_y)
 
         screen.handle.set_window_pos(*pos)
 

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -5,6 +5,12 @@ import threading
 
 from ruamel.yaml import YAML
 
+from module.after_completion_types import (
+    LEGACY_AFTER_COMPLETION_TO_CONFIG,
+    POWER_ACTION_NONE,
+    serialize_after_actions,
+    serialize_power_action,
+)
 from module.logger import log
 from utils.singletonmeta import SingletonMeta
 
@@ -97,33 +103,31 @@ class Config(metaclass=SingletonMeta):
         if saved_version < 1771413380:
             if self.get_value("set_win_position", True) is True:
                 self.unsaved_set_value("set_win_position", "free")
+        if saved_version < 1771965838:
+            if self.get_value("background_click", True) is True:
+                self.unsaved_set_value("win_input_type", "background")
+            else:
+                self.unsaved_set_value("win_input_type", "foreground")
         if saved_version < 1772205660:
             # 迁移旧版结束后动作配置，按字段独立迁移，避免覆盖用户已设置的新字段
+            # 映射表统一由 module.after_completion_types 维护；config 层只负责迁移与落盘。
             legacy_value = int(self.get_value("after_completion", 0) or 0)
-            legacy_to_config = {
-                0: ([], "none"),
-                1: ([], "sleep"),
-                2: ([], "hibernate"),
-                3: ([], "shutdown"),
-                4: (["exit_game"], "none"),
-                5: (["exit_aalc"], "none"),
-                6: (["exit_game", "exit_aalc"], "none"),
-                7: (["exit_emulator"], "none"),
-                8: (["exit_emulator", "exit_aalc"], "none"),
-            }
-            legacy_actions, legacy_power = legacy_to_config.get(legacy_value, ([], "none"))
+            legacy_actions, legacy_power = LEGACY_AFTER_COMPLETION_TO_CONFIG.get(
+                legacy_value, ((), POWER_ACTION_NONE)
+            )
             migrated = False
 
             # 仅在 actions 字段缺失或类型错误时补写
             current_actions = self.get_value("after_completion_actions")
             if not isinstance(current_actions, list):
-                self.unsaved_set_value("after_completion_actions", legacy_actions)
+                # 配置文件保持字符串协议，不直接持久化内部 Enum。
+                self.unsaved_set_value("after_completion_actions", serialize_after_actions(legacy_actions))
                 migrated = True
 
             # 仅在 power_action 字段缺失或类型错误时补写（与 actions 独立判断）
             current_power = self.get_value("after_completion_power_action")
             if not isinstance(current_power, str):
-                self.unsaved_set_value("after_completion_power_action", legacy_power)
+                self.unsaved_set_value("after_completion_power_action", serialize_power_action(legacy_power))
                 migrated = True
 
             if migrated:

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -97,11 +97,37 @@ class Config(metaclass=SingletonMeta):
         if saved_version < 1771413380:
             if self.get_value("set_win_position", True) is True:
                 self.unsaved_set_value("set_win_position", "free")
-        if saved_version < 1771965838:
-            if self.get_value("background_click", True) is True:
-                self.unsaved_set_value("win_input_type", "background")
-            else:
-                self.unsaved_set_value("win_input_type", "foreground")
+        if saved_version < 1772205660:
+            # 迁移旧版结束后动作配置，按字段独立迁移，避免覆盖用户已设置的新字段
+            legacy_value = int(self.get_value("after_completion", 0) or 0)
+            legacy_to_config = {
+                0: ([], "none"),
+                1: ([], "sleep"),
+                2: ([], "hibernate"),
+                3: ([], "shutdown"),
+                4: (["exit_game"], "none"),
+                5: (["exit_aalc"], "none"),
+                6: (["exit_game", "exit_aalc"], "none"),
+                7: (["exit_emulator"], "none"),
+                8: (["exit_emulator", "exit_aalc"], "none"),
+            }
+            legacy_actions, legacy_power = legacy_to_config.get(legacy_value, ([], "none"))
+            migrated = False
+
+            # 仅在 actions 字段缺失或类型错误时补写
+            current_actions = self.get_value("after_completion_actions")
+            if not isinstance(current_actions, list):
+                self.unsaved_set_value("after_completion_actions", legacy_actions)
+                migrated = True
+
+            # 仅在 power_action 字段缺失或类型错误时补写（与 actions 独立判断）
+            current_power = self.get_value("after_completion_power_action")
+            if not isinstance(current_power, str):
+                self.unsaved_set_value("after_completion_power_action", legacy_power)
+                migrated = True
+
+            if migrated:
+                log.info(f"已将旧版结束后操作配置迁移为组合动作（legacy={legacy_value}）")
 
         log.info("配置升级完成")
 

--- a/module/game_and_screen/screen.py
+++ b/module/game_and_screen/screen.py
@@ -465,10 +465,14 @@ class Screen(metaclass=SingletonMeta):
         except Exception as e:
             log.error(f"检查屏幕分辨率失败: {e}")
 
-    def reset_win(self) -> bool:
-        """重置窗口"""
+    def reset_win(self, activate: bool = True) -> bool:
+        """重置窗口。
+
+        任务结束链路会传 activate=False，只恢复窗口样式，不重新抢占前台焦点。
+        """
         try:
             hwnd = self.handle.hwnd
+            log.debug(f"开始重置游戏窗口，activate={activate}")
             # 获取窗口的当前样式
             style = win32gui.GetWindowLong(hwnd, win32con.GWL_STYLE)
             # 获取窗口的当前扩展样式
@@ -486,6 +490,9 @@ class Screen(metaclass=SingletonMeta):
             self.handle.set_window_transparent(False)
 
             # 更新窗口，使样式改变生效
+            frame_flags = win32con.SWP_FRAMECHANGED | win32con.SWP_NOMOVE | win32con.SWP_NOSIZE | win32con.SWP_NOZORDER
+            if not activate:
+                frame_flags |= win32con.SWP_NOACTIVATE
             win32gui.SetWindowPos(
                 hwnd,
                 None,
@@ -493,11 +500,16 @@ class Screen(metaclass=SingletonMeta):
                 0,
                 0,
                 0,
-                win32con.SWP_FRAMECHANGED | win32con.SWP_NOMOVE | win32con.SWP_NOSIZE | win32con.SWP_NOZORDER,
+                frame_flags,
             )
 
             # 恢复窗口状态
-            win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+            # 结束清理只需要恢复外观，不应该把前台再交回游戏窗口。
+            show_cmd = win32con.SW_RESTORE if activate else win32con.SW_SHOWNOACTIVATE
+            win32gui.ShowWindow(hwnd, show_cmd)
+            position_flags = win32con.SWP_NOMOVE | win32con.SWP_NOSIZE
+            if not activate:
+                position_flags |= win32con.SWP_NOACTIVATE
             win32gui.SetWindowPos(
                 hwnd,
                 win32con.HWND_NOTOPMOST,
@@ -505,7 +517,7 @@ class Screen(metaclass=SingletonMeta):
                 0,
                 0,
                 0,
-                win32con.SWP_NOMOVE | win32con.SWP_NOSIZE,
+                position_flags,
             )
 
             # 获取窗口客户区的大小
@@ -516,6 +528,9 @@ class Screen(metaclass=SingletonMeta):
             window_width = self.handle.width()
             window_height = self.handle.height()
 
+            size_flags = win32con.SWP_NOMOVE
+            if not activate:
+                size_flags |= win32con.SWP_NOACTIVATE
             win32gui.SetWindowPos(
                 hwnd,
                 win32con.HWND_NOTOPMOST,
@@ -523,10 +538,11 @@ class Screen(metaclass=SingletonMeta):
                 0,
                 window_width * 2 - client_width,
                 window_height * 2 - client_height,
-                win32con.SWP_NOMOVE,
+                size_flags,
             )
         except Exception as e:
             log.error(f"重置窗口失败: {e}")
             return False
         else:
+            log.debug("重置游戏窗口完成")
             return True

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -1,87 +1,75 @@
 import ctypes
 import os
+import subprocess
+import threading
 from collections.abc import Iterable
-from enum import IntFlag
 
+from module.after_completion_types import (
+    ACTION_EXIT_AALC,
+    ACTION_EXIT_EMULATOR,
+    ACTION_EXIT_GAME,
+    POWER_ACTION_HIBERNATE,
+    POWER_ACTION_LOCK,
+    POWER_ACTION_NONE,
+    POWER_ACTION_SHUTDOWN,
+    POWER_ACTION_SLEEP,
+    normalize_after_actions,
+    normalize_after_completion_config,
+    normalize_power_action,
+)
 from module.config import cfg
 from module.logger import log
 
-# Windows API constants
+# SetThreadExecutionState 常量
 _ES_CONTINUOUS = 0x80000000
 _ES_SYSTEM_REQUIRED = 0x00000001
 _ES_DISPLAY_REQUIRED = 0x00000002
-
-# 退出类动作（建议使用 IntFlag 管理，当前通过字符串映射以保持配置兼容性）
-class ExitAction(IntFlag):
-    NONE = 0
-    EXIT_GAME = 1
-    EXIT_EMULATOR = 2
-    EXIT_AALC = 4
-
-# 字符串映射常量（保持原有引用）
-ACTION_EXIT_GAME = "exit_game"
-ACTION_EXIT_EMULATOR = "exit_emulator"
-ACTION_EXIT_AALC = "exit_aalc"
-
-# 电源类动作（单选，最终执行）
-POWER_ACTION_NONE = "none"
-POWER_ACTION_SLEEP = "sleep"
-POWER_ACTION_HIBERNATE = "hibernate"
-POWER_ACTION_SHUTDOWN = "shutdown"
-POWER_ACTION_LOCK = "lock"
-
-AFTER_ACTIONS_ORDER = [
-    ACTION_EXIT_GAME,
-    ACTION_EXIT_EMULATOR,
-    ACTION_EXIT_AALC,
-]
-
-POWER_ACTIONS = [
-    POWER_ACTION_NONE,
-    POWER_ACTION_SLEEP,
-    POWER_ACTION_HIBERNATE,
-    POWER_ACTION_SHUTDOWN,
-    POWER_ACTION_LOCK,
-]
-
-LEGACY_AFTER_COMPLETION_TO_CONFIG: dict[int, tuple[list[str], str]] = {
-    0: ([], POWER_ACTION_NONE),
-    1: ([], POWER_ACTION_SLEEP),
-    2: ([], POWER_ACTION_HIBERNATE),
-    3: ([], POWER_ACTION_SHUTDOWN),
-    4: ([ACTION_EXIT_GAME], POWER_ACTION_NONE),
-    5: ([ACTION_EXIT_AALC], POWER_ACTION_NONE),
-    6: ([ACTION_EXIT_GAME, ACTION_EXIT_AALC], POWER_ACTION_NONE),
-    7: ([ACTION_EXIT_EMULATOR], POWER_ACTION_NONE),
-    8: ([ACTION_EXIT_EMULATOR, ACTION_EXIT_AALC], POWER_ACTION_NONE),
-}
+_power_keep_awake_lock = threading.Lock()
+# SetThreadExecutionState 绑定调用线程，因此这里不能用单个全局 depth 表达状态。
+_power_keep_awake_depths: dict[int, int] = {}
 
 
-def _normalize_after_actions(actions: Iterable[str] | None) -> list[str]:
-    if not actions:
-        return []
-    normalized: list[str] = []
-    for name in AFTER_ACTIONS_ORDER:
-        if name in actions and name not in normalized:
-            normalized.append(name)
-    return normalized
+def _set_thread_execution_state(state: int) -> None:
+    result = ctypes.windll.kernel32.SetThreadExecutionState(ctypes.c_uint32(state))
+    if result == 0:
+        raise ctypes.WinError()
 
 
-def _normalize_power_action(action: str | None) -> str:
-    if action in POWER_ACTIONS:
-        return action
-    return POWER_ACTION_NONE
+def _update_keep_awake_depth(delta: int) -> tuple[int, int]:
+    # 启用与释放必须在同一线程配对，避免误清理其他线程的执行状态。
+    thread_id = threading.get_ident()
+    with _power_keep_awake_lock:
+        previous_depth = _power_keep_awake_depths.get(thread_id, 0)
+        current_depth = max(0, previous_depth + delta)
+        if current_depth == 0:
+            _power_keep_awake_depths.pop(thread_id, None)
+        else:
+            _power_keep_awake_depths[thread_id] = current_depth
+        return previous_depth, current_depth
+
+
+def _run_command_result(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, capture_output=True, text=True, check=False)
+
+
+def _run_command(command: list[str]) -> int:
+    result = _run_command_result(command)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit={result.returncode}"
+        log.warning(f"命令执行失败 {' '.join(command)}: {detail}")
+    return result.returncode
 
 
 def get_after_completion_config() -> tuple[list[str], str]:
-    actions = _normalize_after_actions(cfg.get_value("after_completion_actions", []))
-    power_action = _normalize_power_action(cfg.get_value("after_completion_power_action", POWER_ACTION_NONE))
-    return actions, power_action
+    # 统一在这里做规范化，避免 UI/任务层各自处理动作协议。
+    return normalize_after_completion_config(
+        cfg.get_value("after_completion_actions", []),
+        cfg.get_value("after_completion_power_action", POWER_ACTION_NONE),
+    )
 
 
 def set_after_completion_config(actions: Iterable[str] | None, power_action: str | None) -> None:
-    normalized_actions = _normalize_after_actions(actions)
-    normalized_power = _normalize_power_action(power_action)
+    normalized_actions, normalized_power = normalize_after_completion_config(actions, power_action)
     cfg.set_value("after_completion_actions", normalized_actions)
     cfg.set_value("after_completion_power_action", normalized_power)
 
@@ -115,25 +103,27 @@ def autodaily_exit_to_after_completion_config(exit_setting: list[bool] | tuple[b
 
 def apply_power_keep_awake(enable: bool) -> None:
     """
-    使用 SetThreadExecutionState 阻止系统/显示器休眠；关闭时恢复默认策略。
-    说明：该 API 只影响调用线程；需要在任务线程中启用并在同一线程关闭。
+    使用 SetThreadExecutionState 阻止系统休眠和关闭显示器。
+    状态绑定在调用线程上，线程结束时由 Windows 自动回收，无需手动 CloseHandle。
+    这里按线程维护深度计数，避免跨线程共享全局状态导致错误释放。
     """
     if os.name != "nt":
         return
+
     try:
         if enable:
-            ret = ctypes.windll.kernel32.SetThreadExecutionState(
-                _ES_CONTINUOUS | _ES_SYSTEM_REQUIRED | _ES_DISPLAY_REQUIRED
-            )
-            if ret == 0:
-                log.warning("启用防息屏失败：SetThreadExecutionState 返回 0")
-            else:
-                log.info("已启用运行时防息屏")
+            previous_depth, _ = _update_keep_awake_depth(1)
+            if previous_depth == 0:
+                state = _ES_CONTINUOUS | _ES_SYSTEM_REQUIRED | _ES_DISPLAY_REQUIRED
+                _set_thread_execution_state(state)
+                log.info("已启用运行时防息屏和保持显示器常亮")
         else:
-            ctypes.windll.kernel32.SetThreadExecutionState(_ES_CONTINUOUS)
-            log.info("已恢复系统默认息屏策略")
-    except Exception as e:
-        log.error(f"设置防息屏状态失败: {e}")
+            previous_depth, current_depth = _update_keep_awake_depth(-1)
+            if previous_depth > 0 and current_depth == 0:
+                _set_thread_execution_state(_ES_CONTINUOUS)
+                log.info("已恢复系统默认息屏策略")
+    except Exception:
+        log.exception("设置防息屏状态失败")
 
 
 def _action_exit_game() -> None:
@@ -143,8 +133,8 @@ def _action_exit_game() -> None:
         log.info("跳过退出游戏：仅支持 Windows")
         return
 
-    if cfg.simulator:
-        if cfg.simulator_type == 0:
+    if cfg.get_value("simulator", False):
+        if cfg.get_value("simulator_type", 0) == 0:
             from module.automation.input_handlers.simulator.mumu_control import (
                 MumuControl,
             )
@@ -174,25 +164,26 @@ def _action_exit_game() -> None:
                 win32process = None
             if win32process is not None:
                 _, pid = win32process.GetWindowThreadProcessId(hwnd)
-                ret = os.system(f"taskkill /F /PID {pid}")
+                ret = _run_command(["taskkill", "/F", "/PID", str(pid)])
                 if ret == 0:
                     log.info("已执行：退出游戏")
                     return
         # 兜底：按进程名结束
-        ret = os.system(f"taskkill /F /IM {cfg.game_process_name}")
+        game_process_name = cfg.get_value("game_process_name", "")
+        ret = _run_command(["taskkill", "/F", "/IM", game_process_name])
         if ret == 0:
             log.info("已执行：退出游戏（进程名兜底）")
         else:
             log.warning("退出游戏失败：未找到可关闭进程或权限不足")
-    except Exception as e:
-        log.error(f"退出游戏失败: {e}")
+    except Exception:
+        log.exception("退出游戏失败")
 
 
 def _action_exit_emulator() -> None:
-    if not cfg.simulator:
+    if not cfg.get_value("simulator", False):
         log.info("跳过退出模拟器：当前未启用模拟器模式")
         return
-    if cfg.simulator_type == 0:
+    if cfg.get_value("simulator_type", 0) == 0:
         from module.automation.input_handlers.simulator.mumu_control import (
             MumuControl,
         )
@@ -210,16 +201,22 @@ def _action_power(power_action: str) -> None:
     if power_action == POWER_ACTION_NONE:
         return
     if power_action == POWER_ACTION_SLEEP:
-        os.system("rundll32.exe powrprof.dll,SetSuspendState Sleep")
+        if _run_command(["rundll32.exe", "powrprof.dll,SetSuspendState", "Sleep"]) == 0:
+            log.info("已执行：睡眠")
         return
     if power_action == POWER_ACTION_HIBERNATE:
-        os.system("rundll32.exe powrprof.dll,SetSuspendState Hibernate")
+        if _run_command(["rundll32.exe", "powrprof.dll,SetSuspendState", "Hibernate"]) == 0:
+            log.info("已执行：休眠")
         return
     if power_action == POWER_ACTION_SHUTDOWN:
-        os.system("shutdown /s /t 30")
+        if _run_command(["shutdown", "/s", "/t", "30"]) == 0:
+            log.info("已执行：关机（30 秒后）")
         return
     if power_action == POWER_ACTION_LOCK:
-        ctypes.windll.user32.LockWorkStation()
+        if ctypes.windll.user32.LockWorkStation() == 0:
+            log.warning("执行锁屏失败：LockWorkStation 返回 0")
+        else:
+            log.info("已执行：锁屏")
         return
     log.warning(f"未知电源动作: {power_action}")
 
@@ -232,8 +229,8 @@ def execute_after_completion(actions: Iterable[str], power_action: str) -> bool:
     if os.name != "nt":
         return False
 
-    normalized_actions = _normalize_after_actions(actions)
-    normalized_power = _normalize_power_action(power_action)
+    normalized_actions = normalize_after_actions(actions)
+    normalized_power = normalize_power_action(power_action)
     should_exit_aalc = ACTION_EXIT_AALC in normalized_actions
 
     for action in normalized_actions:
@@ -246,8 +243,8 @@ def execute_after_completion(actions: Iterable[str], power_action: str) -> bool:
             continue
 
     try:
-        _action_power(normalized_power)
-    except Exception as e:
-        log.error(f"执行电源动作失败: {e}")
+        _action_power(normalized_power.value)
+    except Exception:
+        log.exception("执行电源动作失败")
 
     return should_exit_aalc

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -158,6 +158,10 @@ def apply_power_keep_awake(enable: bool) -> None:
 def _action_exit_game() -> None:
     from module.game_and_screen import game_process, screen
 
+    if os.name != "nt":
+        log.info("跳过退出游戏：仅支持 Windows")
+        return
+
     if cfg.simulator:
         if cfg.simulator_type == 0:
             from module.automation.input_handlers.simulator.mumu_control import (

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -2,11 +2,6 @@ import ctypes
 import os
 from collections.abc import Iterable
 
-try:
-    import win32process
-except ImportError:
-    win32process = None
-
 from module.config import cfg
 from module.logger import log
 
@@ -186,12 +181,17 @@ def _action_exit_game() -> None:
 
     try:
         hwnd = getattr(screen.handle, "hwnd", 0)
-        if hwnd and win32process is not None:
-            _, pid = win32process.GetWindowThreadProcessId(hwnd)
-            ret = os.system(f"taskkill /F /PID {pid}")
-            if ret == 0:
-                log.info("已执行：退出游戏")
-                return
+        if hwnd:
+            try:
+                import win32process
+            except ImportError:
+                win32process = None
+            if win32process is not None:
+                _, pid = win32process.GetWindowThreadProcessId(hwnd)
+                ret = os.system(f"taskkill /F /PID {pid}")
+                if ret == 0:
+                    log.info("已执行：退出游戏")
+                    return
         # 兜底：按进程名结束
         ret = os.system(f"taskkill /F /IM {cfg.game_process_name}")
         if ret == 0:

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -1,0 +1,260 @@
+import ctypes
+import os
+from collections.abc import Iterable
+
+import win32process
+
+from module.config import cfg
+from module.logger import log
+
+# Windows API constants
+_ES_CONTINUOUS = 0x80000000
+_ES_SYSTEM_REQUIRED = 0x00000001
+_ES_DISPLAY_REQUIRED = 0x00000002
+
+# 退出类动作（可多选，按顺序执行）
+ACTION_EXIT_GAME = "exit_game"
+ACTION_EXIT_EMULATOR = "exit_emulator"
+ACTION_EXIT_AALC = "exit_aalc"
+
+# 电源类动作（单选，最终执行）
+POWER_ACTION_NONE = "none"
+POWER_ACTION_SLEEP = "sleep"
+POWER_ACTION_HIBERNATE = "hibernate"
+POWER_ACTION_SHUTDOWN = "shutdown"
+POWER_ACTION_LOCK = "lock"
+
+AFTER_ACTIONS_ORDER = [
+    ACTION_EXIT_GAME,
+    ACTION_EXIT_EMULATOR,
+    ACTION_EXIT_AALC,
+]
+
+POWER_ACTIONS = [
+    POWER_ACTION_NONE,
+    POWER_ACTION_SLEEP,
+    POWER_ACTION_HIBERNATE,
+    POWER_ACTION_SHUTDOWN,
+    POWER_ACTION_LOCK,
+]
+
+LEGACY_AFTER_COMPLETION_TO_CONFIG: dict[int, tuple[list[str], str]] = {
+    0: ([], POWER_ACTION_NONE),
+    1: ([], POWER_ACTION_SLEEP),
+    2: ([], POWER_ACTION_HIBERNATE),
+    3: ([], POWER_ACTION_SHUTDOWN),
+    4: ([ACTION_EXIT_GAME], POWER_ACTION_NONE),
+    5: ([ACTION_EXIT_AALC], POWER_ACTION_NONE),
+    6: ([ACTION_EXIT_GAME, ACTION_EXIT_AALC], POWER_ACTION_NONE),
+    7: ([ACTION_EXIT_EMULATOR], POWER_ACTION_NONE),
+    8: ([ACTION_EXIT_EMULATOR, ACTION_EXIT_AALC], POWER_ACTION_NONE),
+}
+
+
+def _normalize_after_actions(actions: Iterable[str] | None) -> list[str]:
+    if not actions:
+        return []
+    normalized: list[str] = []
+    for name in AFTER_ACTIONS_ORDER:
+        if name in actions and name not in normalized:
+            normalized.append(name)
+    return normalized
+
+
+def _normalize_power_action(action: str | None) -> str:
+    if action in POWER_ACTIONS:
+        return action
+    return POWER_ACTION_NONE
+
+
+def ensure_after_completion_config_migrated() -> None:
+    """
+    兼容旧版 after_completion(int) 到新版组合动作配置。
+    仅在检测到新版配置为空时写入，避免覆盖用户新设置。
+    """
+    current_actions = cfg.get_value("after_completion_actions", None)
+    current_power = cfg.get_value("after_completion_power_action", None)
+    if isinstance(current_actions, list) and isinstance(current_power, str):
+        return
+
+    try:
+        legacy_value = int(cfg.get_value("after_completion", 0) or 0)
+    except Exception:
+        legacy_value = 0
+    actions, power_action = LEGACY_AFTER_COMPLETION_TO_CONFIG.get(legacy_value, ([], POWER_ACTION_NONE))
+    cfg.unsaved_set_value("after_completion_actions", actions)
+    cfg.unsaved_set_value("after_completion_power_action", power_action)
+    cfg.request_save()
+    log.info(f"已将旧版结束后操作配置迁移为组合动作（legacy={legacy_value}）")
+
+
+def get_after_completion_config() -> tuple[list[str], str]:
+    ensure_after_completion_config_migrated()
+    actions = _normalize_after_actions(cfg.get_value("after_completion_actions", []))
+    power_action = _normalize_power_action(cfg.get_value("after_completion_power_action", POWER_ACTION_NONE))
+    return actions, power_action
+
+
+def set_after_completion_config(actions: Iterable[str] | None, power_action: str | None) -> None:
+    normalized_actions = _normalize_after_actions(actions)
+    normalized_power = _normalize_power_action(power_action)
+    cfg.set_value("after_completion_actions", normalized_actions)
+    cfg.set_value("after_completion_power_action", normalized_power)
+
+
+def autodaily_exit_to_after_completion_config(exit_setting: list[bool] | tuple[bool, ...]) -> tuple[list[str], str]:
+    """
+    将 autodaily_task_exit([exit_game, exit_aalc, sleep, hibernate, shutdown, lock]) 转换为统一动作配置。
+    """
+    values = list(exit_setting) if isinstance(exit_setting, (list, tuple)) else []
+    while len(values) < 6:
+        values.append(False)
+
+    actions: list[str] = []
+    if values[0]:
+        actions.append(ACTION_EXIT_GAME)
+    if values[1]:
+        actions.append(ACTION_EXIT_AALC)
+
+    power_action = POWER_ACTION_NONE
+    if values[5]:
+        power_action = POWER_ACTION_LOCK
+    elif values[4]:
+        power_action = POWER_ACTION_SHUTDOWN
+    elif values[3]:
+        power_action = POWER_ACTION_HIBERNATE
+    elif values[2]:
+        power_action = POWER_ACTION_SLEEP
+
+    return actions, power_action
+
+
+def apply_power_keep_awake(enable: bool) -> None:
+    """
+    使用 SetThreadExecutionState 阻止系统/显示器休眠；关闭时恢复默认策略。
+    说明：该 API 只影响调用线程；需要在任务线程中启用并在同一线程关闭。
+    """
+    if os.name != "nt":
+        return
+    try:
+        if enable:
+            ret = ctypes.windll.kernel32.SetThreadExecutionState(
+                _ES_CONTINUOUS | _ES_SYSTEM_REQUIRED | _ES_DISPLAY_REQUIRED
+            )
+            if ret == 0:
+                log.warning("启用防息屏失败：SetThreadExecutionState 返回 0")
+            else:
+                log.info("已启用运行时防息屏")
+        else:
+            ctypes.windll.kernel32.SetThreadExecutionState(_ES_CONTINUOUS)
+            log.info("已恢复系统默认息屏策略")
+    except Exception as e:
+        log.error(f"设置防息屏状态失败: {e}")
+
+
+def _action_exit_game() -> None:
+    from module.game_and_screen import game_process, screen
+
+    if cfg.simulator:
+        if cfg.simulator_type == 0:
+            from module.automation.input_handlers.simulator.mumu_control import (
+                MumuControl,
+            )
+
+            if MumuControl.connection_device is not None:
+                MumuControl.connection_device.close_current_app()
+        else:
+            from module.automation.input_handlers.simulator.simulator_control import (
+                SimulatorControl,
+            )
+
+            if SimulatorControl.connection_device is not None:
+                SimulatorControl.connection_device.close_current_app()
+        log.info("已执行：退出游戏（模拟器）")
+        return
+
+    if not game_process.check_game_alive():
+        log.info("跳过退出游戏：游戏进程未运行")
+        return
+
+    try:
+        hwnd = getattr(screen.handle, "hwnd", 0)
+        if hwnd:
+            _, pid = win32process.GetWindowThreadProcessId(hwnd)
+            ret = os.system(f"taskkill /F /PID {pid}")
+            if ret == 0:
+                log.info("已执行：退出游戏")
+                return
+        # 兜底：按进程名结束
+        ret = os.system(f"taskkill /F /IM {cfg.game_process_name}")
+        if ret == 0:
+            log.info("已执行：退出游戏（进程名兜底）")
+        else:
+            log.warning("退出游戏失败：未找到可关闭进程或权限不足")
+    except Exception as e:
+        log.error(f"退出游戏失败: {e}")
+
+
+def _action_exit_emulator() -> None:
+    if not cfg.simulator:
+        log.info("跳过退出模拟器：当前未启用模拟器模式")
+        return
+    if cfg.simulator_type == 0:
+        from module.automation.input_handlers.simulator.mumu_control import (
+            MumuControl,
+        )
+
+        if MumuControl.connection_device is not None:
+            MumuControl.connection_device.close_simulator()
+            log.info("已执行：退出 MuMu 模拟器")
+        else:
+            log.info("跳过退出 MuMu：未建立连接")
+    else:
+        log.error("退出模拟器失败：暂不支持非 MuMu 模拟器的整机关闭")
+
+
+def _action_power(power_action: str) -> None:
+    if power_action == POWER_ACTION_NONE:
+        return
+    if power_action == POWER_ACTION_SLEEP:
+        os.system("rundll32.exe powrprof.dll,SetSuspendState Sleep")
+        return
+    if power_action == POWER_ACTION_HIBERNATE:
+        os.system("rundll32.exe powrprof.dll,SetSuspendState Hibernate")
+        return
+    if power_action == POWER_ACTION_SHUTDOWN:
+        os.system("shutdown /s /t 30")
+        return
+    if power_action == POWER_ACTION_LOCK:
+        ctypes.windll.user32.LockWorkStation()
+        return
+    log.warning(f"未知电源动作: {power_action}")
+
+
+def execute_after_completion(actions: Iterable[str], power_action: str) -> bool:
+    """
+    执行结束后动作。
+    返回值表示是否需要退出 AALC（由 exit_aalc 动作决定）。
+    """
+    if os.name != "nt":
+        return False
+
+    normalized_actions = _normalize_after_actions(actions)
+    normalized_power = _normalize_power_action(power_action)
+    should_exit_aalc = ACTION_EXIT_AALC in normalized_actions
+
+    for action in normalized_actions:
+        if action == ACTION_EXIT_GAME:
+            _action_exit_game()
+        elif action == ACTION_EXIT_EMULATOR:
+            _action_exit_emulator()
+        elif action == ACTION_EXIT_AALC:
+            # 在 finally 中统一退出，避免提前中断后续动作执行
+            continue
+
+    try:
+        _action_power(normalized_power)
+    except Exception as e:
+        log.error(f"执行电源动作失败: {e}")
+
+    return should_exit_aalc

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -2,7 +2,10 @@ import ctypes
 import os
 from collections.abc import Iterable
 
-import win32process
+try:
+    import win32process
+except ImportError:
+    win32process = None
 
 from module.config import cfg
 from module.logger import log
@@ -179,7 +182,7 @@ def _action_exit_game() -> None:
 
     try:
         hwnd = getattr(screen.handle, "hwnd", 0)
-        if hwnd:
+        if hwnd and win32process is not None:
             _, pid = win32process.GetWindowThreadProcessId(hwnd)
             ret = os.system(f"taskkill /F /PID {pid}")
             if ret == 0:

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -1,6 +1,7 @@
 import ctypes
 import os
 from collections.abc import Iterable
+from enum import IntFlag
 
 from module.config import cfg
 from module.logger import log
@@ -10,7 +11,14 @@ _ES_CONTINUOUS = 0x80000000
 _ES_SYSTEM_REQUIRED = 0x00000001
 _ES_DISPLAY_REQUIRED = 0x00000002
 
-# 退出类动作（可多选，按顺序执行）
+# 退出类动作（建议使用 IntFlag 管理，当前通过字符串映射以保持配置兼容性）
+class ExitAction(IntFlag):
+    NONE = 0
+    EXIT_GAME = 1
+    EXIT_EMULATOR = 2
+    EXIT_AALC = 4
+
+# 字符串映射常量（保持原有引用）
 ACTION_EXIT_GAME = "exit_game"
 ACTION_EXIT_EMULATOR = "exit_emulator"
 ACTION_EXIT_AALC = "exit_aalc"
@@ -65,29 +73,7 @@ def _normalize_power_action(action: str | None) -> str:
     return POWER_ACTION_NONE
 
 
-def ensure_after_completion_config_migrated() -> None:
-    """
-    兼容旧版 after_completion(int) 到新版组合动作配置。
-    仅在检测到新版配置为空时写入，避免覆盖用户新设置。
-    """
-    current_actions = cfg.get_value("after_completion_actions", None)
-    current_power = cfg.get_value("after_completion_power_action", None)
-    if isinstance(current_actions, list) and isinstance(current_power, str):
-        return
-
-    try:
-        legacy_value = int(cfg.get_value("after_completion", 0) or 0)
-    except Exception:
-        legacy_value = 0
-    actions, power_action = LEGACY_AFTER_COMPLETION_TO_CONFIG.get(legacy_value, ([], POWER_ACTION_NONE))
-    cfg.unsaved_set_value("after_completion_actions", actions)
-    cfg.unsaved_set_value("after_completion_power_action", power_action)
-    cfg.request_save()
-    log.info(f"已将旧版结束后操作配置迁移为组合动作（legacy={legacy_value}）")
-
-
 def get_after_completion_config() -> tuple[list[str], str]:
-    ensure_after_completion_config_migrated()
     actions = _normalize_after_actions(cfg.get_value("after_completion_actions", []))
     power_action = _normalize_power_action(cfg.get_value("after_completion_power_action", POWER_ACTION_NONE))
     return actions, power_action

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -410,10 +410,8 @@ class my_script_task(QThread):
         except Exception as e:
             self.exception = e
             self.exc_traceback = "".join(format_exception(type(e), e, e.__traceback__))
-            log.error(f"出现错误: {e}")
+            log.error(self.exc_traceback)
         finally:
-            if self.exc_traceback:
-                log.error(self.exc_traceback)
             self.mutex.unlock()
 
         mediator.finished_signal.emit()
@@ -423,7 +421,7 @@ class my_script_task(QThread):
         self.finished_signal.emit()"""
 
     def _run(self):
-        keep_awake_enabled = bool(getattr(cfg, "experimental_keep_screen_awake", False))
+        keep_awake_enabled = bool(cfg.get_value("experimental_keep_screen_awake", False))
         try:
             if keep_awake_enabled:
                 apply_power_keep_awake(True)

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -430,11 +430,6 @@ class my_script_task(QThread):
             ret = script_task()
             if ret == 0:
                 mediator.kill_signal.emit()
-        except Exception as e:
-            log.error(f"出现错误: {e}")
-            self.exc_traceback = "".join(format_exception(*exc_info()))
-            log.error(self.exc_traceback)
-            self.mutex.unlock()
         finally:
             if keep_awake_enabled:
                 apply_power_keep_awake(False)

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -409,10 +409,10 @@ class my_script_task(QThread):
             self.exception = e
         except Exception as e:
             self.exception = e
+            self.exc_traceback = "".join(format_exception(type(e), e, e.__traceback__))
             log.error(f"出现错误: {e}")
         finally:
-            if self.exc_traceback != "":
-                self.exc_traceback = "".join(format_exception(*exc_info()))
+            if self.exc_traceback:
                 log.error(self.exc_traceback)
             self.mutex.unlock()
 

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -1,4 +1,3 @@
-import os
 import platform
 import random
 from datetime import datetime
@@ -6,7 +5,6 @@ from sys import exc_info
 from time import sleep, time
 from traceback import format_exception
 
-import win32process
 from playsound3 import playsound
 from PySide6.QtCore import QT_TRANSLATE_NOOP, QMutex, QThread
 
@@ -22,6 +20,11 @@ from module.config import cfg
 from module.decorator.decorator import begin_and_finish_time_log
 from module.game_and_screen import game_process, screen
 from module.logger import log
+from module.system_actions import (
+    apply_power_keep_awake,
+    execute_after_completion,
+    get_after_completion_config,
+)
 from module.my_error.my_error import (
     backMainWinError,
     cannotOperateGameError,
@@ -370,39 +373,12 @@ def script_task() -> None | int:
         Resonate_with_Ahab()
 
     if platform.system() == "Windows":
-        after_completion = cfg.after_completion
+        actions, power_action = get_after_completion_config()
         try:
-            if after_completion == 1:
-                os.system("rundll32.exe powrprof.dll,SetSuspendState Sleep")
-            elif after_completion == 2:
-                os.system("rundll32.exe powrprof.dll,SetSuspendState Hibernate")
-            elif after_completion == 3:
-                os.system("shutdown /s /t 30")
-            elif after_completion == 4 or after_completion == 6:
-                _, pid = win32process.GetWindowThreadProcessId(screen.handle.hwnd)
-                ret = os.system(f"taskkill /F /PID {pid}")
-                if ret == 0:
-                    log.info("成功关闭 Limbus Company")
-                elif ret == 128:
-                    log.error("错误：进程不存在")
-                elif ret == 1:
-                    log.error("错误：权限不足")
-            elif after_completion == 7:
-                if cfg.simulator_type == 0:
-                    from module.automation.input_handlers.simulator.mumu_control import (
-                        MumuControl,
-                    )
-
-                    MumuControl.connection_device.close_simulator()
-                else:
-                    log.error("错误：暂不支持退出其他模拟器进程")
-
+            if execute_after_completion(actions, power_action):
+                return 0
         except Exception as e:
             log.error(f"脚本结束后的操作失败: {e}")
-
-        finally:
-            if after_completion in [5, 6, 8]:
-                return 0  # 正常退出信号
 
 
 class my_script_task(QThread):
@@ -447,13 +423,19 @@ class my_script_task(QThread):
         self.finished_signal.emit()"""
 
     def _run(self):
+        keep_awake_enabled = bool(getattr(cfg, "experimental_keep_screen_awake", False))
         try:
+            if keep_awake_enabled:
+                apply_power_keep_awake(True)
             ret = script_task()
             if ret == 0:
                 mediator.kill_signal.emit()
-            auto.clear_img_cache()
         except Exception as e:
             log.error(f"出现错误: {e}")
             self.exc_traceback = "".join(format_exception(*exc_info()))
             log.error(self.exc_traceback)
             self.mutex.unlock()
+        finally:
+            if keep_awake_enabled:
+                apply_power_keep_awake(False)
+            auto.clear_img_cache()

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -1,9 +1,7 @@
 import platform
 import random
 from datetime import datetime
-from sys import exc_info
 from time import sleep, time
-from traceback import format_exception
 
 from playsound3 import playsound
 from PySide6.QtCore import QT_TRANSLATE_NOOP, QMutex, QThread
@@ -98,10 +96,7 @@ def onetime_mir_process(team_setting, team_num: int):
         else:
             return False
     except Exception as e:
-        msg = f"镜牢行动出错: {e}"
-        exc_traceback = "".join(format_exception(*exc_info()))
-        msg += f"\n调用栈信息:\n{exc_traceback}"
-        log.error(msg)
+        log.exception(f"镜牢行动出错: {e}")
         return False
 
 
@@ -345,7 +340,8 @@ def script_task() -> None | int:
         task()
 
     if cfg.set_reduce_miscontact and not cfg.simulator:
-        screen.reset_win()
+        # 任务已结束，这里只恢复游戏窗口样式，避免把前台重新切回游戏。
+        screen.reset_win(activate=False)
     if cfg.simulator:
         if cfg.simulator_type == 0:
             from module.automation.input_handlers.simulator.mumu_control import (
@@ -377,15 +373,14 @@ def script_task() -> None | int:
         try:
             if execute_after_completion(actions, power_action):
                 return 0
-        except Exception as e:
-            log.error(f"脚本结束后的操作失败: {e}")
+        except Exception:
+            log.exception("脚本结束后的操作失败")
 
 
 class my_script_task(QThread):
     def __init__(self):
         # 初始化，构造函数
         super().__init__()
-        self.exc_traceback = ""
         self.mutex = QMutex()
 
     def run(self):
@@ -409,8 +404,7 @@ class my_script_task(QThread):
             self.exception = e
         except Exception as e:
             self.exception = e
-            self.exc_traceback = "".join(format_exception(type(e), e, e.__traceback__))
-            log.error(self.exc_traceback)
+            log.exception("脚本线程执行失败")
         finally:
             self.mutex.unlock()
 
@@ -430,5 +424,8 @@ class my_script_task(QThread):
                 mediator.kill_signal.emit()
         finally:
             if keep_awake_enabled:
+                # 先切回 AALC 再释放线程级防息屏，避免游戏仍持有前台时继续阻止息屏。
+                mediator.request_focus.emit()
+                self.msleep(800)  # 覆盖 WinRT toast 异步归还焦点（延迟约 600ms），再释放防息屏
                 apply_power_keep_awake(False)
             auto.clear_img_cache()


### PR DESCRIPTION
1. **结束后操作组合配置**：支持退出游戏/模拟器/AALC等前置动作，以及锁屏、睡眠、休眠、关机等最终电源动作
2. **运行时防息屏**：实验性功能，运行期间阻止系统与显示器休眠，任务结束自动恢复
3. **配置迁移**：兼容旧版 after_completion 整数配置到新版组合动作配置
4. **UI界面**：新增结束后操作编辑器和选择器组件，支持仅本次生效或保存默认

- module/system_actions.py：新增系统动作执行模块
- app/farming_interface.py：新增结束后操作UI组件
- app/setting_interface.py：添加防息屏实验功能开关
- app/my_app.py：集成定时任务与结束后动作配置转换
- app/base_combination.py：添加锁屏复选框
- assets/config/config.example.yaml：新增配置项
- tasks/base/script_task_scheme.py：集成防息屏功能与清理逻辑优化

- 锁屏操作仅支持 Windows 系统
- 防息屏功能需在实验性功能中手动开启
- 配置向后兼容，旧版 after_completion 配置自动迁移