### PR TITLE
关于使用Interception驱动层点击的改动

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ __main_dev_temp__.py
 # 其他
 MaaFramework
 .worktrees
+
+# Interception 驱动（运行时下载）
+interception

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -213,6 +213,7 @@ win_input_type_options = {
     QT_TRANSLATE_NOOP("ComboBoxSettingCard", "前台模式 (pyautogui)"): "foreground",
     QT_TRANSLATE_NOOP("ComboBoxSettingCard", "后台模式 (默认) (pywin32)"): "background",
     QT_TRANSLATE_NOOP("ComboBoxSettingCard", "后台增强 (pywin32+set_window_pos)"): "window_move",
+    QT_TRANSLATE_NOOP("ComboBoxSettingCard", "驱动点击 (interception-python)"): "driver",
 }
 
 

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -3,6 +3,9 @@ import re
 import subprocess
 import sys
 from enum import Enum
+from interception import auto_capture_devices
+from interception.exceptions import DriverNotFoundError
+import requests
 
 from PySide6.QtCore import (
     QEvent,
@@ -171,6 +174,27 @@ class MainWindow(FramelessWindow):
             self.dev_watermark = DevWatermark(self)
             self.dev_watermark.move(0, 0)
             self.dev_watermark.raise_()
+        
+        try:
+            auto_capture_devices()
+        except DriverNotFoundError:
+            log.error("Interception 驱动未安装!正在尝试自动安装驱动")
+            # 开始自动安装驱动
+            file_name = os.path.join(str(os.environ.get("TEMP")),"install_interception.exe")
+            resp = requests.get("https://hk.gh-proxy.org/https://github.com/oblitum/Interception/releases/download/v1.0.1/Interception.zip") # 从 GhProxy 源下载Interception安装程序
+            if not resp.ok:
+                log.error("Interception 驱动下载失败!")
+            else:
+                log.info("Interception 驱动下载成功!")
+            with open(file_name,"wb") as f:
+                f.write(resp.content)
+            exit_code = subprocess.call([file_name, "/install"])
+            if exit_code == 0:
+                log.info("Interception 驱动安装成功!请重启电脑!")
+            else:
+                log.error("Interception 驱动安装失败!")
+        finally:
+            log.info("Interception 初始化完成!")
 
         self.connect_mediator()
 

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -6,6 +6,7 @@ from enum import Enum
 from interception import auto_capture_devices
 from interception.exceptions import DriverNotFoundError
 import requests
+import zipfile
 
 from PySide6.QtCore import (
     QEvent,
@@ -175,26 +176,33 @@ class MainWindow(FramelessWindow):
             self.dev_watermark.move(0, 0)
             self.dev_watermark.raise_()
         
-        try:
-            auto_capture_devices()
-        except DriverNotFoundError:
-            log.error("Interception 驱动未安装!正在尝试自动安装驱动")
-            # 开始自动安装驱动
-            file_name = os.path.join(str(os.environ.get("TEMP")),"install_interception.exe")
-            resp = requests.get("https://hk.gh-proxy.org/https://github.com/oblitum/Interception/releases/download/v1.0.1/Interception.zip") # 从 GhProxy 源下载Interception安装程序
-            if not resp.ok:
-                log.error("Interception 驱动下载失败!")
-            else:
-                log.info("Interception 驱动下载成功!")
-            with open(file_name,"wb") as f:
-                f.write(resp.content)
-            exit_code = subprocess.call([file_name, "/install"])
-            if exit_code == 0:
-                log.info("Interception 驱动安装成功!请重启电脑!")
-            else:
-                log.error("Interception 驱动安装失败!")
-        finally:
-            log.info("Interception 初始化完成!")
+        input_type = cfg.win_input_type
+        if input_type == "driver":
+            try:
+                auto_capture_devices()
+            except DriverNotFoundError:
+                log.error("Interception 驱动未安装!正在尝试自动安装驱动")
+                # 开始自动安装驱动
+                file_name = os.path.join(str(os.environ.get("TEMP")),"interception.zip")
+                tg_file_name = "./interception/Interception/command line installer/install-interception.exe"
+                resp = requests.get("https://hk.gh-proxy.org/https://github.com/oblitum/Interception/releases/download/v1.0.1/Interception.zip") # 从 GhProxy 源下载Interception安装程序
+                if not resp.ok:
+                    log.error("Interception 驱动下载失败!")
+                else:
+                    log.info("Interception 驱动下载成功!")
+                with open(file_name,"wb") as f:
+                    f.write(resp.content)
+                # 解压命令行安装器
+                with zipfile.ZipFile(file_name, 'r') as zf:
+                    zf.extractall("./interception")
+                    log.info("解压成功")
+                exit_code = subprocess.call([tg_file_name, "/install"])
+                if exit_code == 0:
+                    log.info("Interception 驱动安装成功!请重启电脑!")
+                else:
+                    log.error("Interception 驱动安装失败!")
+            finally:
+                log.info("Interception 初始化完成!")
 
         self.connect_mediator()
 

--- a/app/my_app.py
+++ b/app/my_app.py
@@ -176,33 +176,6 @@ class MainWindow(FramelessWindow):
             self.dev_watermark.move(0, 0)
             self.dev_watermark.raise_()
         
-        input_type = cfg.win_input_type
-        if input_type == "driver":
-            try:
-                auto_capture_devices()
-            except DriverNotFoundError:
-                log.error("Interception 驱动未安装!正在尝试自动安装驱动")
-                # 开始自动安装驱动
-                file_name = os.path.join(str(os.environ.get("TEMP")),"interception.zip")
-                tg_file_name = "./interception/Interception/command line installer/install-interception.exe"
-                resp = requests.get("https://hk.gh-proxy.org/https://github.com/oblitum/Interception/releases/download/v1.0.1/Interception.zip") # 从 GhProxy 源下载Interception安装程序
-                if not resp.ok:
-                    log.error("Interception 驱动下载失败!")
-                else:
-                    log.info("Interception 驱动下载成功!")
-                with open(file_name,"wb") as f:
-                    f.write(resp.content)
-                # 解压命令行安装器
-                with zipfile.ZipFile(file_name, 'r') as zf:
-                    zf.extractall("./interception")
-                    log.info("解压成功")
-                exit_code = subprocess.call([tg_file_name, "/install"])
-                if exit_code == 0:
-                    log.info("Interception 驱动安装成功!请重启电脑!")
-                else:
-                    log.error("Interception 驱动安装失败!")
-            finally:
-                log.info("Interception 初始化完成!")
 
         self.connect_mediator()
 

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -584,6 +584,12 @@ class SettingInterface(QWidget):
                 "基于移动窗口的后台模式，有效规避了后台模式需要移动鼠标的情况，<br/>但是性能和稳定性较差，<font color=red>不推荐长时间无人使用</font>",
             )
             cfg.set_value("background_click", True)
+        elif input_type == "driver":
+            content = QT_TRANSLATE_NOOP(
+                "ComboBoxSettingCard",
+                "驱动点击，有效规避脚本检测，<font color=red>但需安装Interception驱动且不稳定!!</font>(其余与前台模式相同)",
+            )
+            cfg.set_value("background_click", False)
         else:
             content = QT_TRANSLATE_NOOP("ComboBoxSettingCard", "未知的输入模式，发生了错误")
 

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -879,6 +879,10 @@ Right-click to set as permanent</translation>
         <translation>Background Mode Enhancement(pywin32+set win pos)</translation>
     </message>
     <message>
+        <source>驱动点击 (interception-python)</source>
+        <translation>Driver Mode (interception-python)</translation>
+    </message>
+    <message>
         <source>操控方式</source>
         <translation>Control method</translation>
     </message>

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import socket
 import sys
 import threading
+import interception
 
 # 解决 Windows DPI 缩放问题
 from ctypes import c_void_p, windll

--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -67,6 +67,11 @@ class Automation(metaclass=SingletonMeta):
 
                 log.debug("使用基于窗口移动的后台点击模块")
                 self.input_handler = WindowMoveInput()
+            elif input_type == "driver":
+                from .input_handlers.input import DriverInput
+                
+                log.debug("使用驱动点击模块")
+                self.input_handler = DriverInput()
         if self.input_handler is None:
             from .input_handlers.input import BackgroundInput
 

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -3,6 +3,13 @@ from time import sleep, time
 import time
 from typing import overload
 
+import zipfile
+import os
+import subprocess
+import requests
+import pyuac
+import shutil
+
 import pyautogui
 import win32api
 import win32con
@@ -772,6 +779,37 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
 
 class DriverInput(WinAbstractInput, metaclass=SingletonMeta):
     """基于 `interception-python` 的输入类, 仅支持前台操作"""
+    
+    def __init__(self):
+        # Interception初始化
+        input_type = cfg.win_input_type
+        if input_type == "driver" and pyuac.isUserAdmin():
+            try:
+                interception.auto_capture_devices()
+            except DriverNotFoundError:
+                log.error("Interception 驱动未安装!正在尝试自动安装驱动")
+                # 开始自动安装驱动
+                file_name = os.path.join(str(os.environ.get("TEMP")),"interception.zip")
+                tg_file_name = "./interception/Interception/command line installer/install-interception.exe"
+                resp = requests.get("https://hk.gh-proxy.org/https://github.com/oblitum/Interception/releases/download/v1.0.1/Interception.zip") # 从 GhProxy 源下载Interception安装程序
+                if not resp.ok:
+                    log.error("Interception 驱动下载失败!")
+                else:
+                    log.info("Interception 驱动下载成功!")
+                with open(file_name,"wb") as f:
+                    f.write(resp.content)
+                # 解压命令行安装器
+                with zipfile.ZipFile(file_name, 'r') as zf:
+                    zf.extractall("./interception")
+                    log.info("解压成功")
+                exit_code = subprocess.call([tg_file_name, "/install"])
+                if exit_code == 0:
+                    shutil.rmtree("./interception")
+                    log.info("Interception 驱动安装成功!请重启电脑!")
+                else:
+                    log.error("Interception 驱动安装失败!")
+            finally:
+                log.info("Interception 初始化完成!")
     
     @overload
     def pos_offset(self, x: int, y: int) -> tuple[int, int]: ...

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -1,5 +1,6 @@
 import random
 from time import sleep, time
+import time
 from typing import overload
 
 import pyautogui
@@ -812,10 +813,22 @@ class DriverInput(WinAbstractInput, metaclass=SingletonMeta):
 
         scale = cfg.set_win_size / 1080
         x, y = self.pos_offset(x, y)
+        target_x = x
+        target_y = y + int(300 * scale * reverse)
         interception.move_to(x, y)
         interception.mouse_down(button="left")
-        interception.move_to(x, y + int(300 * scale * reverse))
-        sleep(0.4)
+        
+        start_time = time.perf_counter()
+        duration = 0.4
+        elapsed = 0.0
+        while elapsed < duration:
+            progress = elapsed / duration
+            current_y = int(y + (target_y - y) * progress)
+            interception.move_to(x, current_y)
+            time.sleep(1/120)
+            elapsed = time.perf_counter() - start_time
+        interception.move_to(target_x, target_y)
+        
         interception.mouse_up("left")
 
         if move_back and current_mouse_position:
@@ -825,13 +838,29 @@ class DriverInput(WinAbstractInput, metaclass=SingletonMeta):
         if move_back:
             current_mouse_position = self.get_mouse_position()
         x, y = self.pos_offset(x, y)
+        
+        # 移动到起点并按下左键
         interception.move_to(x, y)
         interception.mouse_down("left")
-        interception.move_to(x + dx, y + dy)
-        if drag_time * 0.3 > 0.5:
-            sleep(drag_time * 0.3)
-        else:
-            sleep(0.5)
+        
+        # 平滑拖动到终点
+        target_x = x + dx
+        target_y = y + dy
+        start_time = time.perf_counter()
+        elapsed = 0.0
+        while elapsed < drag_time:
+            progress = elapsed / drag_time
+            current_x = int(x + (target_x - x) * progress)
+            current_y = int(y + (target_y - y) * progress)
+            interception.move_to(current_x, current_y)
+            time.sleep(1/120)
+            elapsed = time.perf_counter() - start_time
+        interception.move_to(target_x, target_y)
+        
+        # 等待按住停留时间（与 pyautogui 版本一致）
+        sleep_time = drag_time * 0.3 if drag_time * 0.3 > 0.5 else 0.5
+        time.sleep(sleep_time)
+        
         interception.mouse_up("left")
 
         if move_back and current_mouse_position:

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -7,6 +7,8 @@ import win32api
 import win32con
 import win32gui
 from pywintypes import error as PyWinTypesError
+import interception
+from interception.exceptions import DriverNotFoundError
 
 from module.config import cfg
 from utils.singletonmeta import SingletonMeta
@@ -765,3 +767,143 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         screen.handle.set_window_pos(*pos)
         self.wait_pause()
         return True
+
+
+class DriverInput(WinAbstractInput, metaclass=SingletonMeta):
+    """基于 `interception-python` 的输入类, 仅支持前台操作"""
+    
+    @overload
+    def pos_offset(self, x: int, y: int) -> tuple[int, int]: ...
+    @overload
+    def pos_offset(self, pos: tuple[int, int]) -> tuple[int, int]: ...
+
+    def pos_offset(self, *args) -> tuple[int, int]:  # type: ignore
+        """根据当前窗口位置偏移点击位置"""
+        if len(args) == 2:
+            x, y = args
+        elif isinstance(args[0], tuple):
+            x, y = args[0]
+        else:
+            raise ValueError("pos_offset 接受两个整数参数或一个包含两个整数的元组")
+        real_x, real_y, _, _ = screen.handle.rect(True)
+        return x + real_x, y + real_y
+
+    def mouse_click(self, x, y, times=1, move_back=False) -> bool:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        msg = f"点击位置:({x},{y})"
+        log.debug(msg, stacklevel=2)
+        x, y = self.pos_offset(x, y)
+        for i in range(times):
+            interception.click(x, y)
+            # 多次点击执行很快所以暂停放到循环外
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+        self.wait_pause()
+
+        return True
+
+    def mouse_drag_down(self, x, y, reverse=1, move_back=True) -> None:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        scale = cfg.set_win_size / 1080
+        x, y = self.pos_offset(x, y)
+        interception.move_to(x, y)
+        interception.mouse_down(button="left")
+        interception.move_to(x, y + int(300 * scale * reverse))
+        sleep(0.4)
+        interception.mouse_up("left")
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+    def mouse_drag(self, x, y, drag_time=0.1, dx=0, dy=0, move_back=True) -> None:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+        x, y = self.pos_offset(x, y)
+        interception.move_to(x, y)
+        interception.mouse_down("left")
+        interception.move_to(x + dx, y + dy)
+        if drag_time * 0.3 > 0.5:
+            sleep(drag_time * 0.3)
+        else:
+            sleep(0.5)
+        interception.mouse_up("left")
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+    def mouse_scroll(self, direction: int = -3) -> bool:
+        if direction <= 0:
+            msg = "鼠标滚动滚轮，远离界面"
+        else:
+            msg = "鼠标滚动滚轮，拉近界面"
+        log.debug(msg, stacklevel=2)
+        if direction >= 0:
+            for _ in range(direction):
+                interception.scroll("up")
+        else:
+            for _ in range(abs(direction)):
+                interception.scroll("down")
+        return True
+
+    def mouse_click_blank(self, coordinate=(1, 1), times=1, move_back=False) -> bool:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        msg = "点击（1，1）空白位置"
+        log.debug(msg, stacklevel=2)
+        x = coordinate[0] + random.randint(0, 10)
+        y = coordinate[1] + random.randint(0, 10)
+        x, y = self.pos_offset(x, y)
+        for i in range(times):
+            interception.click(x, y)
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+        self.wait_pause()
+        return True
+
+    def mouse_to_blank(self, coordinate=(1, 1), move_back=False) -> None:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        msg = "鼠标移动到空白，避免遮挡"
+        log.debug(msg, stacklevel=2)
+        interception.move_to(coordinate[0], coordinate[1])
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+        self.wait_pause()
+
+    def mouse_move(self, coordinate=(1, 1)) -> None:
+        """鼠标移动到指定坐标
+
+        Args:
+            coordinate (tuple): 坐标元组 (x, y)
+        """
+        interception.move_to(coordinate[0], coordinate[1])
+        self.wait_pause()
+
+    def mouse_drag_link(self, position: list, drag_time=0.1, move_back=False) -> None:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        x, y = self.pos_offset(position[0][0], position[0][1])
+        interception.move_to(x, y)
+        interception.mouse_down("left")
+        for pos in position:
+            x, y = self.pos_offset(pos[0], pos[1])
+            interception.move_to(x, y)
+        pyautogui.mouseUp()
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+    def key_press(self, key):
+        return interception.press(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "tzdata>=2025.2",
     "adbutils>=2.10.2",
     "windows-toasts>=1.3.1",
+    "interception-python>=1.13.6",
+    "pyclick>=0.0.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ dependencies = [
     { name = "adbutils" },
     { name = "colorlog" },
     { name = "concurrent-log-handler" },
+    { name = "interception-python" },
     { name = "linkify-it-py" },
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
@@ -47,6 +48,7 @@ dependencies = [
     { name = "playsound3" },
     { name = "psutil" },
     { name = "pyautogui" },
+    { name = "pyclick" },
     { name = "pynput" },
     { name = "pyperclip" },
     { name = "pyside6" },
@@ -72,6 +74,7 @@ requires-dist = [
     { name = "adbutils", specifier = ">=2.10.2" },
     { name = "colorlog", specifier = ">=6.9.0" },
     { name = "concurrent-log-handler", specifier = ">=0.9.28" },
+    { name = "interception-python", specifier = ">=1.13.6" },
     { name = "linkify-it-py" },
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
@@ -83,6 +86,7 @@ requires-dist = [
     { name = "playsound3" },
     { name = "psutil" },
     { name = "pyautogui" },
+    { name = "pyclick", specifier = ">=0.0.2" },
     { name = "pynput" },
     { name = "pyperclip" },
     { name = "pyside6", specifier = ">=6.9.2" },
@@ -278,6 +282,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "interception-python"
+version = "1.13.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/af/ade2c411c7e4ef42c1320d83eb8f500064f51f272ec2a05c746670b91864/interception_python-1.13.6.tar.gz", hash = "sha256:bf6a9750e40ca8599daa6c05f88748dd7efe040aea7f1aba258d2789a9930eda", size = 22137, upload-time = "2025-07-15T13:47:28.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b9/609095f4c70d771dab361e50490941fd5cc735ab88c066ed8a60638115b9/interception_python-1.13.6-py3-none-any.whl", hash = "sha256:c14b0047513a7c1728b55e0516cbfbd99b1315a80e1a5aaf408baf8e9f937b3b", size = 22352, upload-time = "2025-07-15T13:47:27.648Z" },
 ]
 
 [[package]]
@@ -629,6 +642,22 @@ dependencies = [
     { name = "pytweening" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/ff/cdae0a8c2118a0de74b6cf4cbcdcaf8fd25857e6c3f205ce4b1794b27814/PyAutoGUI-0.9.54.tar.gz", hash = "sha256:dd1d29e8fd118941cb193f74df57e5c6ff8e9253b99c7b04f39cfc69f3ae04b2", size = 61236, upload-time = "2023-05-24T20:11:32.972Z" }
+
+[[package]]
+name = "pyclick"
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyautogui" },
+    { name = "python3-xlib" },
+    { name = "pytweening" },
+    { name = "xlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/af/10fccae5d26c05dacdf05245453666feac4185eead5f9e0dd4da03f4f3b9/pyclick-0.0.2.tar.gz", hash = "sha256:0d4ef59faae3e313d36305a68e20d404581f54033706005939c7255e439afff1", size = 3977, upload-time = "2018-09-20T22:45:57.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/91/75a30b68eaf0dc646093873d1fb464fca75dab7fb41ac2dd85468712af81/pyclick-0.0.2-py3-none-any.whl", hash = "sha256:393c13eb8b54c70552d5e231ad0ef7b81c8ab72cd820fbe42d5f67f3808876af", size = 5156, upload-time = "2018-09-20T22:45:55.813Z" },
+]
 
 [[package]]
 name = "pyclipper"
@@ -3965,4 +3994,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/43/c81672457002908b8c0f1e4672db1d0b8885c2894c6768fe9b0162af9ee5/winrt_windows_ui_notifications-3.2.1-cp314-cp314-win32.whl", hash = "sha256:00a7579ca0870134c27def1418c259fb18efe5b88aa399de85b4712f1add1b55", size = 157561, upload-time = "2025-09-20T07:19:10.162Z" },
     { url = "https://files.pythonhosted.org/packages/17/d8/910a58698d722120f2401c3bfeb6018361d92f3b2814caae839f54693305/winrt_windows_ui_notifications-3.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:943599c727abf710ae94644b1d521e11857bd568e080e894a8be11aa717e383a", size = 170152, upload-time = "2025-09-20T07:19:11.05Z" },
     { url = "https://files.pythonhosted.org/packages/b5/a3/1db0f2ec28a4eadd0876c0ac3a3d78514027c5afe35737b164e03c98b234/winrt_windows_ui_notifications-3.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2a496c7e796b537966df7b26753b20bc40c5c1fbe96b3b3051a1debc00b80f07", size = 163245, upload-time = "2025-09-20T07:19:12.352Z" },
+]
+
+[[package]]
+name = "xlib"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/d4/6033a97f96fc7d7bb822dab52e2e3c9532256d7ce033fa9675734941b9ac/xlib-0.21.tar.gz", hash = "sha256:60b7cd5d90f5d5922d9ce27b61589c07d970796558d417461db7b66e366bc401", size = 146776, upload-time = "2018-01-02T09:39:40.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/00/321541273b0ed2167b36c82be9baeb0bdc8af1c11c1b01de9436b84b5eaf/xlib-0.21-py2.py3-none-any.whl", hash = "sha256:8eee67dad83ef4b82bbbfa85d51eeb20c79d12b119fe25aa1d27bd602ff82212", size = 123811, upload-time = "2018-01-02T09:39:33.518Z" },
 ]


### PR DESCRIPTION
**本人第一次写pr，不好请见谅**
**使用interception暂不稳定，测试较少（时间原因），以及不知道小金是否有做其他形式的检测，因此请谨慎使用**
**本人无鼓励使用脚本意图，尊重所有手动玩家！！！**
**没搞懂i18n怎么写，因此没写完**

# 依赖简介
[interception-python](https://github.com/kennyhml/pyinterception)是一个基于python实现的使用[interception](https://github.com/oblitum/Interception)的驱动层点击工具，可有效规避小金基于注入flag（下图）的检测
<img width="694" height="48" alt="image" src="https://github.com/user-attachments/assets/f4203218-b269-4117-8663-7fc48161d165" />

# 小金究竟是如何检测的？
如AALC、LALC一众的边狱巴士脚本（下文均以AALC为例）基本是使用`pyautogui`,`pywin32api`等库发送鼠标点击消息，以pywin32api举例，发送鼠标消息是使用
<img width="286" height="164" alt="image" src="https://github.com/user-attachments/assets/d92504fa-3c34-4137-ad57-c236c14141ae" />
这个函数↑进行
但是这个函数发送的信息会被windows打上**LLKHF_INJECTED**或**LLMHF_INJECTED**标签（合成输入标签），而小金就会在游戏中统计并上传这些数据（具体不再赘述），并以此进行封禁。
详见[关于键盘合成输入标签](https://learn.microsoft.com/zh-cn/windows/win32/api/winuser/ns-winuser-kbdllhookstruct)
[关于鼠标合成输入标签](http://learn.microsoft.com/zh-cn/windows/win32/api/winuser/ns-winuser-msllhookstruct)
[脚本禁用详解](https://tieba.baidu.com/p/10626807944)

# 如何绕过这个检测（即这个改动在做的事）？
如依赖简介所示，[interception](https://github.com/oblitum/Interception)是一个驱动级api，原理为通过伪造驱动消息来实现不使用Windows API来进行点击
<img width="691" height="586" alt="原理流程图" src="https://github.com/user-attachments/assets/0bbf97a3-3364-43ce-9103-1ca926c530a3" />
这样就不会被小金检测到了

# 这个改动干了什么？
增加了驱动点击模式与自动从ghproxy源安装interception驱动，没了