### PR TITLE
fix: 修复旧配置 team_history 为 None 时升级崩溃

### DIFF
--- a/module/config/config.py
+++ b/module/config/config.py
@@ -148,7 +148,7 @@ class Config(metaclass=SingletonMeta):
                 if settings is None:
                     continue
                 remark_name: str | None = loaded_config.get(f"team{i}_remark_name", None)
-                history: dict = loaded_config.get(f"team{i}_history", {})
+                history: dict = loaded_config.get(f"team{i}_history", {}) or {}
 
                 settings.update(history)
                 settings["remark_name"] = remark_name


### PR DESCRIPTION
修复某些情况下旧配置文件`team_history`未能初始化导致的配置升级崩溃进而导致AALC主程序无法正常启动的问题。