### PR TITLE
修复命令行启动问题；修复定时任务界面点击保存窗口不会关闭的问题。

### DIFF
--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -1111,6 +1111,13 @@ class AutoDailyView(FlyoutViewBase):
             self.exit_setting = list(self.exit_setting) + [False] * (6 - len(self.exit_setting))
         cfg.set_value(self.config_name + "_task", self.setting)
         cfg.set_value(self.config_name + "_task_exit", self.exit_setting)
+        # 关闭弹出窗
+        parent_card = self.__search_parent_class("DailySettingCard")
+        if parent_card is not None and hasattr(parent_card, "_popup"):
+            try:
+                parent_card._popup.close()
+            except Exception:
+                pass
 
     def __search_parent_class(self, class_name="DailySettingCard"):
         current = self.parentWidget()
@@ -1174,7 +1181,7 @@ class DailySettingCard(SwitchSettingCard):
         self.retranslateUi()
 
     def __show_view(self):
-        PopupTeachingTip.make(
+        self._popup = PopupTeachingTip.make(
             target=self.button,
             view=AutoDailyView(self),
             tailPosition=TeachingTipTailPosition.RIGHT,

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -729,8 +729,9 @@ class FarmingInterfaceLeft(QWidget):
         # 连接所有可能信号
         mediator.link_start.connect(self.my_stop_shortcut)
         mediator.kill_signal.connect(self.stop_AALC)
-        # finished_signal 表示线程自然结束，不应再走开始/停止按钮的副作用逻辑。
-        mediator.finished_signal.connect(self._on_script_finished)
+        # finished_signal 目前用于命令行延迟触发开始/停止按钮逻辑。
+        mediator.finished_signal.connect(self.start_and_stop_tasks)
+        mediator.script_finished.connect(self._on_script_finished)
 
     def retranslateUi(self):
         self.set_windows.retranslateUi()

--- a/app/mediator.py
+++ b/app/mediator.py
@@ -17,6 +17,7 @@ class Mediator(QObject):
     download_complete = Signal(str)
     warning = Signal(str)
     finished_signal = Signal()
+    script_finished = Signal()
     kill_signal = Signal()
     # 任务线程通过信号请求主窗口抢回前台，避免跨层直接操作 UI。
     request_focus = Signal()

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -435,7 +435,7 @@ class my_script_task(QThread):
         finally:
             self.mutex.unlock()
 
-        mediator.finished_signal.emit()
+        mediator.script_finished.emit()
 
     """def stop(self):
         self.running=False


### PR DESCRIPTION
## 做了什么？
1. 命令行 --start 无效 — 拆分 finished_signal / script_finished 信号，修复了代码中一个信号承担"启动任务"和"完成清理"两个互斥职责的问题
2. 定时任务设置弹窗保存不关闭 — AutoDailyView.__save() 保存后自动关闭父级 TeachingTip

## 关联 issues
fix #603 
fix #602 