### PR TITLE
fix: 修复 Mumu 模拟器退出时序冲突导致连接断开 (fix #617)

### DIFF
--- a/module/automation/input_handlers/simulator/pyminitouch/utils.py
+++ b/module/automation/input_handlers/simulator/pyminitouch/utils.py
@@ -47,7 +47,7 @@ def restart_adb():
     # adbutils 没有专门的 start_server 方法，
     # 因为当你尝试获取 server 版本或设备列表时，如果服务没启动，它会自动尝试启动。
     # 所以，调用一下 server_version() 是最标准的“唤醒/检查”操作。
-    print(f"ADB Server version: {adbutils.adb.server_version()}")
+    log.debug(f"ADB Server version: {adbutils.adb.server_version()}")
 
 
 def is_device_connected(device_id):

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -366,13 +366,6 @@ def script_task() -> None | int:
     if cfg.set_reduce_miscontact and not cfg.simulator:
         # 任务已结束，这里只恢复游戏窗口样式，避免把前台重新切回游戏。
         screen.reset_win(activate=False)
-    if cfg.simulator:
-        if cfg.simulator_type == 0:
-            from module.automation.input_handlers.simulator.mumu_control import (
-                MumuControl,
-            )
-
-            MumuControl.clean_connect()
 
     log.info("脚本任务已经完成")
     QT_TRANSLATE_NOOP("WindowsToast", "AALC 运行结束")
@@ -392,13 +385,24 @@ def script_task() -> None | int:
     if cfg.resonate_with_Ahab:
         Resonate_with_Ahab()
 
+    should_exit_aalc = False
     if platform.system() == "Windows":
         actions, power_action = get_after_completion_config()
         try:
-            if execute_after_completion(actions, power_action):
-                return 0
+            should_exit_aalc = execute_after_completion(actions, power_action)
         except Exception:
             log.exception("脚本结束后的操作失败")
+
+    if cfg.simulator:
+        if cfg.simulator_type == 0:
+            from module.automation.input_handlers.simulator.mumu_control import (
+                MumuControl,
+            )
+
+            MumuControl.clean_connect()
+
+    if should_exit_aalc:
+        return 0
 
 
 class my_script_task(QThread):


### PR DESCRIPTION
- 将 MumuControl.clean_connect() 移至 execute_after_completion() 之后
- 避免退出游戏时提前断开模拟器连接，导致后续退出模拟器操作失败
- 新增 should_exit_aalc 变量，确保退出操作与模拟器清理的顺序正确
- 将 pyminitouch/utils.py 中的 debug print 改为 log.debug()
- fix #617