### PR TITLE
feat: 新增实验性开关-模拟器中文支持

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -411,7 +411,7 @@ class SettingInterface(QWidget):
             QT_TRANSLATE_NOOP("SwitchSettingCard", "模拟器已安装零协汉化"),
             QT_TRANSLATE_NOOP(
                 "SwitchSettingCard",
-                "开启后不强制英语，也许能够在零协汉化的模拟器版上运行，不做稳定性保证",
+                "开启后不强制英语，也许能够在零协汉化的模拟器版上运行，<font color=red>不做稳定性保证</font>",
             ),
             config_name="experimental_simulator_chinese_patch",
             parent=self.experimental_group,

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -406,6 +406,16 @@ class SettingInterface(QWidget):
             config_name="experimental_keep_screen_awake",
             parent=self.experimental_group,
         )
+        self.simulator_chinese_patch_card = SwitchSettingCard(
+            FIF.LANGUAGE,
+            QT_TRANSLATE_NOOP("SwitchSettingCard", "模拟器已安装零协汉化"),
+            QT_TRANSLATE_NOOP(
+                "SwitchSettingCard",
+                "开启后不强制英语，也许能够在零协汉化的模拟器版上运行，不做稳定性保证",
+            ),
+            config_name="experimental_simulator_chinese_patch",
+            parent=self.experimental_group,
+        )
 
     def _on_hard_mirror_chance_confirm(self, _: int) -> None:
         """手动调整困难模式次数后，同步刷新自动切换时间戳。"""
@@ -457,6 +467,7 @@ class SettingInterface(QWidget):
 
         self.experimental_group.addSettingCard(self.auto_lang_card)
         self.experimental_group.addSettingCard(self.keep_screen_awake_card)
+        self.experimental_group.addSettingCard(self.simulator_chinese_patch_card)
 
         self.expand_layout.addWidget(self.game_setting_group)
         self.expand_layout.addWidget(self.theme_pack_group)
@@ -693,6 +704,7 @@ class SettingInterface(QWidget):
         self.experimental_group.retranslateUi()
         self.auto_lang_card.retranslateUi()
         self.keep_screen_awake_card.retranslateUi()
+        self.simulator_chinese_patch_card.retranslateUi()
 
     def __onThemeCardChanged(self):
         theme_mode = cfg.get_value("theme_mode")

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -62,6 +62,7 @@ resonate_with_Ahab: False # 是否播放亚哈语录
 # 实验性功能
 experimental_auto_lang: True # 是否自动修改语言
 experimental_keep_screen_awake: False # 运行期间阻止系统与显示器休眠，任务结束自动恢复
+experimental_simulator_chinese_patch: False # 模拟器已安装零协汉化：开启后不强制英文，不做稳定性保证
 
 
 

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -2254,6 +2254,16 @@ Right-click to set as permanent</translation>
         <source>任务运行中阻止系统休眠与锁屏；任务结束、停止或异常退出后会自动恢复系统默认策略</source>
         <translation>Prevented from entering sleep mode or locking the screen for running</translation>
     </message>
+    <message>
+        <location filename="../app/setting_interface.py" line="409"/>
+        <source>模拟器已安装零协汉化</source>
+        <translation>Simulator has Chinese patch installed</translation>
+    </message>
+    <message>
+        <location filename="../app/setting_interface.py" line="413"/>
+        <source>开启后不强制英语，也许能够在零协汉化的模拟器版上运行，不做稳定性保证</source>
+        <translation>Disables forced English; may work with Chinese-patched simulator, no stability guarantee</translation>
+    </message>
 </context>
 <context>
     <name>TeamSettingCard</name>

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -2261,8 +2261,8 @@ Right-click to set as permanent</translation>
     </message>
     <message>
         <location filename="../app/setting_interface.py" line="413"/>
-        <source>开启后不强制英语，也许能够在零协汉化的模拟器版上运行，不做稳定性保证</source>
-        <translation>Disables forced English; may work with Chinese-patched simulator, no stability guarantee</translation>
+        <source>开启后不强制英语，也许能够在零协汉化的模拟器版上运行，&lt;font color=red&gt;不做稳定性保证&lt;/font&gt;</source>
+        <translation>Disables forced English; may work with Chinese-patched simulator, &lt;font color=red&gt;no stability guarantee&lt;/font&gt;</translation>
     </message>
 </context>
 <context>

--- a/module/ALI/autoLangIdentification.py
+++ b/module/ALI/autoLangIdentification.py
@@ -21,6 +21,8 @@ class AutoSwitchCon:
     "语言不同并自动切换"
     FAILED: int = 2
     "语言切换失败, 可能是不支持的语言"
+    SKIPPED: int = 3
+    "有意跳过语言识别（如模拟器汉化模式）"
 
 
 def auto_switch_language_in_game(hwnd: int) -> int:
@@ -30,15 +32,16 @@ def auto_switch_language_in_game(hwnd: int) -> int:
     ---
 
     Returns:
-        int: 从0-2三种情况 可以查看AutoSwitchCon类
-            - 0: 当前语言相同
-            - 1: 当前语言不同, 但位于支持的语言列表中 (自动切换)
-            - 2: 当前语言不同, 且不支持
+        int: 返回值对应 AutoSwitchCon 中的枚举
+            - 0 (FINISH): 当前语言相同
+            - 1 (CHANGED): 当前语言不同但已自动切换
+            - 2 (FAILED): 语言切换失败（不支持的语言）
+            - 3 (SKIPPED): 有意跳过语言识别（如模拟器汉化模式）
     """
     if cfg.simulator:
         if cfg.experimental_simulator_chinese_patch:
             log.info("检测到模拟器且已开启零协汉化模式，跳过强制英文")
-            return AutoSwitchCon.FINISH
+            return AutoSwitchCon.SKIPPED
         log.info("检测到模拟器，将自动使用英文")
         cfg.set_value("language_in_game", "en")
         return AutoSwitchCon.FINISH

--- a/module/ALI/autoLangIdentification.py
+++ b/module/ALI/autoLangIdentification.py
@@ -36,6 +36,9 @@ def auto_switch_language_in_game(hwnd: int) -> int:
             - 2: 当前语言不同, 且不支持
     """
     if cfg.simulator:
+        if cfg.experimental_simulator_chinese_patch:
+            log.info("检测到模拟器且已开启零协汉化模式，跳过强制英文")
+            return AutoSwitchCon.FINISH
         log.info("检测到模拟器，将自动使用英文")
         cfg.set_value("language_in_game", "en")
         return AutoSwitchCon.FINISH

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -343,6 +343,9 @@ class ConfigModel(BaseModel):
     experimental_auto_lang: bool = True
     """是否自动修改语言"""
 
+    experimental_simulator_chinese_patch: bool = False
+    """模拟器已安装零协汉化（模拟器下不做稳定性保证）"""
+
     simulator: bool = False
     """是否使用模拟器"""
 

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -320,7 +320,7 @@ def script_task() -> None | int:
         log.error(f"自动切换语言出错: {e}，使用英语尝试")
         cfg.set_value("language_in_game", "en")
 
-    if cfg.simulator and cfg.language_in_game != "en":
+    if cfg.simulator and not cfg.experimental_simulator_chinese_patch and cfg.language_in_game != "en":
         log.info("模拟器模式下强制使用英文图片与文本识别")
         cfg.set_value("language_in_game", "en")
 


### PR DESCRIPTION
- module/config/config_typing.py — 新增配置项 experimental_simulator_chinese_patch: bool = False
- app/setting_interface.py — 实验性功能分组新增开关卡片，提示语：在零协汉化的模拟器版上运行，不做稳定性保证
- module/ALI/autoLangIdentification.py — 模拟器检测时先判断开关：开启则跳过强制英文，保留用户设定语言
- tasks/base/script_task_scheme.py — 兜底强制逻辑追加条件 not cfg.experimental_simulator_chinese_patch
- assets/config/config.example.yaml — 同步添加配置示例
- i18n/myapp_en.ts — 添加中英文翻译
fix (0b81117) — Review 改进
- autoLangIdentification.py: 新增 AutoSwitchCon.SKIPPED 枚举（=3）替代原有的 FINISH，语义更精确
- setting_interface.py: 提示文字中"不做稳定性保证"增加 <font color=red> 红色高亮

fix #616 