### PR TITLE
feat: 添加队伍和主题包配置导入导出功能，优化界面交互

### DIFF
--- a/app/page_card.py
+++ b/app/page_card.py
@@ -14,6 +14,9 @@ from PySide6.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QWidget, QFileDi
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import (
     Action,
+    InfoBar,
+    InfoBarPosition,
+    MessageBox,
     PopUpAniStackedWidget,
     RoundMenu,
     ScrollArea,
@@ -645,7 +648,7 @@ class PageMirror(PageCard):
                 cfg.save()
 
     def show_team_creation_menu(self):
-        """Show menu with options to create team from scratch or from file"""
+        """显示菜单，提供从头创建队伍或从文件创建的选项"""
         menu = RoundMenu(parent=self)
 
         create_new_action = Action(FIF.ADD, self.tr("创建空白队伍"))
@@ -656,14 +659,12 @@ class PageMirror(PageCard):
         create_from_file_action.triggered.connect(self.create_team_from_file)
         menu.addAction(create_from_file_action)
 
-        # Show menu at button position
+        # 在按钮位置显示菜单
         menu.exec(self.add_team_button.mapToGlobal(self.add_team_button.rect().bottomLeft()))
 
     def create_team_from_file(self):
-        """Create a new team from an imported configuration file"""
-        from qfluentwidgets import InfoBar, InfoBarPosition, MessageBox
-
-        # Open file dialog to select YAML file
+        """从导入的配置文件创建新队伍"""
+        # 打开文件对话框选择 YAML 文件
         file_path, _ = QFileDialog.getOpenFileName(
             self,
             self.tr("选择队伍配置文件"),
@@ -674,7 +675,7 @@ class PageMirror(PageCard):
         if not file_path:
             return
 
-        # Import team settings from file
+        # 从文件导入队伍设置
         team_setting, theme_pack_weight, missing_fields = import_team_settings(file_path, 1)
 
         if team_setting is None:
@@ -685,7 +686,7 @@ class PageMirror(PageCard):
             ).exec()
             return
 
-        # Show warning if fields are missing
+        # 如果字段缺失则显示警告
         if missing_fields:
             missing_text = "\n- ".join(missing_fields)
             w = MessageBox(
@@ -698,10 +699,10 @@ class PageMirror(PageCard):
             if not w.exec():
                 return
 
-        # Auto-increment to next available team slot
+        # 自动递增到下一个可用的队伍槽位
         existing_teams = sorted([int(k) for k in cfg.config.teams.keys()])
 
-        # Find the next available slot
+        # 查找下一个可用槽位
         team_num = None
         for i in range(1, 21):
             if i not in existing_teams:
@@ -716,17 +717,17 @@ class PageMirror(PageCard):
             ).exec()
             return
 
-        # Apply the imported settings
+        # 应用导入的设置
         try:
             apply_team_settings(team_num, team_setting, theme_pack_weight)
 
-            # Add to teams_be_select and teams_order
+            # 添加到 teams_be_select 和 teams_order
             while len(cfg.config.teams_be_select) < team_num:
                 cfg.config.teams_be_select.append(False)
             while len(cfg.config.teams_order) < team_num:
                 cfg.config.teams_order.append(0)
 
-            # Refresh the UI
+            # 刷新界面
             self.get_setting()
 
             InfoBar.success(
@@ -934,7 +935,7 @@ class MarkdownViewer(QWidget):
         layout.addWidget(self.text_browser)
         self.help_path = file_path
 
-        # Connect theme change signal after help_path is set
+        # 在设置 help_path 后连接主题变化信号
         qconfig.themeChanged.connect(self.updateStyle)
         self.reset_viewer()
 
@@ -947,7 +948,7 @@ class MarkdownViewer(QWidget):
 
     def handle_link_clicked(self, url: QUrl):
         """
-        Decides how to handle a clicked link in the QTextBrowser.
+        处理 QTextBrowser 中点击链接的逻辑
         """
         if url.scheme() in ["http", "https"]:
             # 用系统默认浏览器打开外部链接

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -10,10 +10,12 @@ from PySide6.QtGui import (
     QPainter,
     QTextDocument,
 )
-from PySide6.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QWidget, QFileDialog
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import (
+    Action,
     PopUpAniStackedWidget,
+    RoundMenu,
     ScrollArea,
     TextBrowser,
     TransparentToolButton,
@@ -36,6 +38,7 @@ from app.common.ui_config import get_theme_aware_text_browser_qss
 from app.language_manager import SUPPORTED_GAME_LANG_NAME, LanguageManager
 from app.widget.custom_segmented_widget import CustomSegmentedWidget
 from module.config import TeamSetting, cfg, theme_list
+from module.config.team_import_export import apply_team_settings, import_team_settings
 from module.logger import log
 
 from .markdown_it_imgdiv import imgdiv_plugin, render_div_close, render_div_open
@@ -423,7 +426,7 @@ class PageMirror(PageCard):
         self.add_team = QHBoxLayout()
         self.add_team_button = TransparentToolButton(FIF.ADD, None)
         self.add_team_button.setMinimumWidth(200)
-        self.add_team_button.clicked.connect(self.new_team)
+        self.add_team_button.clicked.connect(self.show_team_creation_menu)
 
         self.hard_mirror = BaseCheckBox(
             "hard_mirror",
@@ -641,6 +644,108 @@ class PageMirror(PageCard):
                 theme_list.create_team_weight_config(number)
                 cfg.save()
 
+    def show_team_creation_menu(self):
+        """Show menu with options to create team from scratch or from file"""
+        menu = RoundMenu(parent=self)
+
+        create_new_action = Action(FIF.ADD, self.tr("创建空白队伍"))
+        create_new_action.triggered.connect(self.new_team)
+        menu.addAction(create_new_action)
+
+        create_from_file_action = Action(FIF.FOLDER_ADD, self.tr("从现有配置创建"))
+        create_from_file_action.triggered.connect(self.create_team_from_file)
+        menu.addAction(create_from_file_action)
+
+        # Show menu at button position
+        menu.exec(self.add_team_button.mapToGlobal(self.add_team_button.rect().bottomLeft()))
+
+    def create_team_from_file(self):
+        """Create a new team from an imported configuration file"""
+        from qfluentwidgets import InfoBar, InfoBarPosition, MessageBox
+
+        # Open file dialog to select YAML file
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("选择队伍配置文件"),
+            "",
+            "YAML Files (*.yaml *.yml)"
+        )
+
+        if not file_path:
+            return
+
+        # Import team settings from file
+        team_setting, theme_pack_weight, missing_fields = import_team_settings(file_path, 1)
+
+        if team_setting is None:
+            MessageBox(
+                self.tr("导入失败"),
+                self.tr("无法读取配置文件，请检查文件格式是否正确。"),
+                self
+            ).exec()
+            return
+
+        # Show warning if fields are missing
+        if missing_fields:
+            missing_text = "\n- ".join(missing_fields)
+            w = MessageBox(
+                self.tr("缺少字段"),
+                self.tr(f"配置文件中缺少以下字段：\n- {missing_text}\n\n将使用默认值填充这些字段。是否继续？"),
+                self
+            )
+            w.yesButton.setText(self.tr("继续"))
+            w.cancelButton.setText(self.tr("取消"))
+            if not w.exec():
+                return
+
+        # Auto-increment to next available team slot
+        existing_teams = sorted([int(k) for k in cfg.config.teams.keys()])
+
+        # Find the next available slot
+        team_num = None
+        for i in range(1, 21):
+            if i not in existing_teams:
+                team_num = i
+                break
+
+        if team_num is None:
+            MessageBox(
+                self.tr("无可用队伍槽位"),
+                self.tr("已达到最大队伍数量（20个），无法创建新队伍。"),
+                self
+            ).exec()
+            return
+
+        # Apply the imported settings
+        try:
+            apply_team_settings(team_num, team_setting, theme_pack_weight)
+
+            # Add to teams_be_select and teams_order
+            while len(cfg.config.teams_be_select) < team_num:
+                cfg.config.teams_be_select.append(False)
+            while len(cfg.config.teams_order) < team_num:
+                cfg.config.teams_order.append(0)
+
+            # Refresh the UI
+            self.get_setting()
+
+            InfoBar.success(
+                title=self.tr("导入成功"),
+                content=self.tr(f"已成功从文件创建队伍 {team_num}"),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=2000,
+                parent=self
+            )
+        except Exception as e:
+            log.error(f"Failed to create team from file: {e}")
+            MessageBox(
+                self.tr("创建失败"),
+                self.tr(f"创建队伍时出错：{str(e)}"),
+                self
+            ).exec()
+
     def remove_team_card(self, target: str):
         try:
             team = self.findChild(MirrorTeamCombination, target)
@@ -685,8 +790,8 @@ class PageMirror(PageCard):
                 continue
             cfg.config.teams[f"{save_index}"] = cfg.config.teams[f"{index}"]
             del cfg.config.teams[f"{index}"]
-            theme_list.set_team_weight_config_from_team(i, i + 1)
-            theme_list.delete_team_weight_config(i + 1)
+            theme_list.set_team_weight_config_from_team(save_index, int(index))
+            theme_list.delete_team_weight_config(int(index))
             save_index += 1
 
         cfg.save()
@@ -723,6 +828,7 @@ class PageMirror(PageCard):
         self.not_skip_whitegossypium.retranslateUi()
         self.fight_to_last_man.retranslateUi()
         self.mirror_keyboard_navigation.retranslateUi()
+        self.add_team_button.setToolTip(self.tr("添加队伍"))
         for child in self.findChildren(MirrorTeamCombination):
             child.retranslateUi()
 

--- a/app/team_setting_card.py
+++ b/app/team_setting_card.py
@@ -450,7 +450,7 @@ class TeamSettingCard(QFrame):
         mediator.close_setting.emit()
 
     def on_export_settings(self):
-        """Export team settings to YAML file"""
+        """导出队伍设置到 YAML 文件"""
         default_filename = generate_team_export_filename(self.team_num)
         file_path, _ = QFileDialog.getSaveFileName(
             self,
@@ -483,7 +483,7 @@ class TeamSettingCard(QFrame):
                 )
 
     def on_import_settings(self):
-        """Import team settings from YAML file"""
+        """从 YAML 文件导入队伍设置"""
         file_path, _ = QFileDialog.getOpenFileName(
             self,
             self.tr("导入队伍设置"),
@@ -508,7 +508,7 @@ class TeamSettingCard(QFrame):
             )
             return
 
-        # Show warning if there are missing fields
+        # 如果有缺失字段则显示警告
         if missing_fields:
             BaseInfoBar.warning(
                 title=self.tr("部分字段缺失"),
@@ -520,7 +520,7 @@ class TeamSettingCard(QFrame):
                 parent=self
             )
 
-        # Show confirmation dialog
+        # 显示确认对话框
         confirm = MessageBoxConfirm(
             self.tr("确认导入"),
             self.tr("导入将覆盖当前队伍设置，是否继续？"),

--- a/app/team_setting_card.py
+++ b/app/team_setting_card.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QResizeEvent
 from PySide6.QtWidgets import (
+    QFileDialog,
     QFrame,
     QGridLayout,
     QHBoxLayout,
@@ -8,7 +9,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import ExpandSettingCard, PrimaryPushButton, PushButton, ScrollArea
+from qfluentwidgets import ExpandSettingCard, InfoBarPosition, PrimaryPushButton, PushButton, ScrollArea
 from qfluentwidgets import FluentIcon as FIF
 
 from app import *
@@ -20,10 +21,17 @@ from app.base_combination import (
     ToolCheckButton,
 )
 from app.base_tools import BaseCheckBox, BaseComboBox, BaseLabel, BaseSettingLayout
+from app.card.messagebox_custom import BaseInfoBar, MessageBoxConfirm
 from app.common.icons import OverflowIcons
 from app.language_manager import LanguageManager
 from app.theme_pack_setting_interface import ThemePackSettingDialog
 from module.config import TeamSetting, cfg, theme_list
+from module.config.team_import_export import (
+    apply_team_settings,
+    export_team_settings,
+    generate_team_export_filename,
+    import_team_settings,
+)
 
 
 class TeamSettingCard(QFrame):
@@ -220,6 +228,11 @@ class TeamSettingCard(QFrame):
             self.open_theme_pack_weight_dialog
         )
 
+        self.export_button = PrimaryPushButton(self.tr("导出设置"))
+        self.export_button.clicked.connect(self.on_export_settings)
+        self.import_button = PushButton(self.tr("导入设置"))
+        self.import_button.clicked.connect(self.on_import_settings)
+
         self.cancel_button = PushButton(self.tr("取消"))
         self.cancel_button.clicked.connect(self.cancel_team_setting)
         self.confirm_button = PrimaryPushButton(self.tr("保存"))
@@ -259,6 +272,9 @@ class TeamSettingCard(QFrame):
         self.gift_system_layout.add(self.gift_system_list_1)
         self.gift_system_layout.add(self.gift_system_list_2)
 
+        self.setting_layout.addWidget(self.export_button)
+        self.setting_layout.addWidget(self.import_button)
+        self.setting_layout.addStretch()
         self.setting_layout.addWidget(self.cancel_button)
         self.setting_layout.addWidget(self.confirm_button)
 
@@ -433,6 +449,100 @@ class TeamSettingCard(QFrame):
     def cancel_team_setting(self):
         mediator.close_setting.emit()
 
+    def on_export_settings(self):
+        """Export team settings to YAML file"""
+        default_filename = generate_team_export_filename(self.team_num)
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            self.tr("导出队伍设置"),
+            default_filename,
+            "YAML Files (*.yaml *.yml)"
+        )
+
+        if file_path:
+            success = export_team_settings(self.team_num, file_path)
+            if success:
+                BaseInfoBar.success(
+                    title=self.tr("导出成功"),
+                    content=self.tr("队伍设置已导出到: ") + file_path,
+                    orient=Qt.Orientation.Horizontal,
+                    isClosable=True,
+                    position=InfoBarPosition.TOP,
+                    duration=3000,
+                    parent=self
+                )
+            else:
+                BaseInfoBar.error(
+                    title=self.tr("导出失败"),
+                    content=self.tr("无法导出队伍设置，请检查日志"),
+                    orient=Qt.Orientation.Horizontal,
+                    isClosable=True,
+                    position=InfoBarPosition.TOP,
+                    duration=3000,
+                    parent=self
+                )
+
+    def on_import_settings(self):
+        """Import team settings from YAML file"""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("导入队伍设置"),
+            "",
+            "YAML Files (*.yaml *.yml)"
+        )
+
+        if not file_path:
+            return
+
+        team_setting, theme_pack_weight, missing_fields = import_team_settings(file_path, self.team_num)
+
+        if team_setting is None:
+            BaseInfoBar.error(
+                title=self.tr("导入失败"),
+                content=self.tr("无法解析导入文件，请检查文件格式"),
+                orient=Qt.Orientation.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
+            return
+
+        # Show warning if there are missing fields
+        if missing_fields:
+            BaseInfoBar.warning(
+                title=self.tr("部分字段缺失"),
+                content=self.tr("以下字段将使用默认值: ") + ", ".join(missing_fields),
+                orient=Qt.Orientation.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=5000,
+                parent=self
+            )
+
+        # Show confirmation dialog
+        confirm = MessageBoxConfirm(
+            self.tr("确认导入"),
+            self.tr("导入将覆盖当前队伍设置，是否继续？"),
+            self.window()
+        )
+
+        if confirm.exec():
+            apply_team_settings(self.team_num, team_setting, theme_pack_weight)
+            self.team_setting = team_setting
+            self.read_settings()
+            self.refresh_starlight_select()
+
+            BaseInfoBar.success(
+                title=self.tr("导入成功"),
+                content=self.tr("队伍设置已导入并应用"),
+                orient=Qt.Orientation.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
+
     def retranslateUi(self):
         self.select_system.retranslateUi()
         self.select_shop_strategy.retranslateUi()
@@ -464,6 +574,8 @@ class TeamSettingCard(QFrame):
         self.pierce.check_box.setText(self.tr("突刺"))
         self.blunt.check_box.setText(self.tr("打击"))
 
+        self.export_button.setText(self.tr("导出设置"))
+        self.import_button.setText(self.tr("导入设置"))
         self.cancel_button.setText(self.tr("取消"))
         self.confirm_button.setText(self.tr("保存"))
 

--- a/app/theme_pack_setting_interface.py
+++ b/app/theme_pack_setting_interface.py
@@ -1,8 +1,10 @@
 import copy
+import re
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
+    QFileDialog,
     QFrame,
     QGridLayout,
     QHBoxLayout,
@@ -11,9 +13,14 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 from qfluentwidgets import (
+    Action,
     BodyLabel,
+    DropDownPushButton,
+    FluentIcon as FIF,
+    InfoBarPosition,
     PrimaryPushButton,
     PushButton,
+    RoundMenu,
     ScrollArea,
     SubtitleLabel,
     TitleLabel,
@@ -23,9 +30,14 @@ from qframelesswindow import FramelessDialog, StandardTitleBar
 from ruamel.yaml import YAML
 
 from app.base_tools import BaseSpinBox
-from app.card.messagebox_custom import MessageBoxConfirm
+from app.card.messagebox_custom import BaseInfoBar, MessageBoxConfirm
 from module import THEME_PACK_LIST_EXAMPLE_PATH
 from module.config import cfg, theme_list
+from module.config.theme_pack_import_export import (
+    export_theme_pack_weight,
+    generate_theme_pack_export_filename,
+    import_theme_pack_weight,
+)
 
 # 英文key到中文名称的映射表（普通模式）
 THEME_PACK_NAME_MAP = {
@@ -546,21 +558,43 @@ class ThemePackSettingDialog(FramelessDialog):
         self.button_widget = QWidget()
         self.button_widget.setObjectName("button_widget")
         self.button_layout = QHBoxLayout(self.button_widget)
-        self.button_layout.setContentsMargins(0, 10, 0, 10)
+        self.button_layout.setContentsMargins(20, 10, 20, 10)
+        self.button_layout.setSpacing(8)
 
-        self.reset_button = PushButton(self.tr("重置为默认"), self)
-        self.reset_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        self.reset_button.clicked.connect(self.reset_to_default)
+        # 批量操作下拉菜单按钮
+        self.batch_menu_button = DropDownPushButton(self.tr("批量操作"), self)
+        self.batch_menu_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.batch_menu = RoundMenu(parent=self)
 
-        self.set_to_global_button = PushButton(self.tr("拉取全局配置"), self)
-        self.set_to_global_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        self.set_to_global_button.clicked.connect(self.set_to_global)
-        self.set_to_global_button.setVisible(self.is_team_specific)
+        self.reset_action = Action(FIF.SYNC, self.tr("重置为默认"))
+        self.reset_action.triggered.connect(self.reset_to_default)
+        self.batch_menu.addAction(self.reset_action)
 
-        self.set_all_negative_button = PushButton(self.tr("全部设为 -5"), self)
-        self.set_all_negative_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
-        self.set_all_negative_button.clicked.connect(self.set_all_weights_negative)
+        self.set_to_global_action = Action(FIF.DOWNLOAD, self.tr("拉取全局配置"))
+        self.set_to_global_action.triggered.connect(self.set_to_global)
+        self.batch_menu.addAction(self.set_to_global_action)
 
+        self.set_all_negative_action = Action(FIF.REMOVE, self.tr("全部设为 -5"))
+        self.set_all_negative_action.triggered.connect(self.set_all_weights_negative)
+        self.batch_menu.addAction(self.set_all_negative_action)
+
+        self.batch_menu_button.setMenu(self.batch_menu)
+
+        # Connect to show menu upward
+        self.batch_menu_button.clicked.connect(lambda: self._show_menu_upward(self.batch_menu_button, self.batch_menu))
+
+        # 导入导出按钮（仅队伍特定配置显示）
+        self.export_button = PushButton(FIF.UP, self.tr("导出"))
+        self.export_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.export_button.clicked.connect(self.on_export_settings)
+        self.export_button.setVisible(self.is_team_specific)
+
+        self.import_button = PushButton(FIF.DOWN, self.tr("导入"))
+        self.import_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.import_button.clicked.connect(self.on_import_settings)
+        self.import_button.setVisible(self.is_team_specific)
+
+        # 主要操作按钮
         self.save_button = PrimaryPushButton(self.tr("保存并关闭"), self)
         self.save_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.save_button.clicked.connect(self.save_and_close)
@@ -569,13 +603,12 @@ class ThemePackSettingDialog(FramelessDialog):
         self.close_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.close_button.clicked.connect(self.close)
 
+        self.button_layout.addWidget(self.batch_menu_button)
+        self.button_layout.addWidget(self.export_button)
+        self.button_layout.addWidget(self.import_button)
         self.button_layout.addStretch()
-        self.button_layout.addWidget(self.reset_button)
-        self.button_layout.addWidget(self.set_to_global_button)
-        self.button_layout.addWidget(self.set_all_negative_button)
         self.button_layout.addWidget(self.save_button)
         self.button_layout.addWidget(self.close_button)
-        self.button_layout.addStretch()
 
     def __init_layout(self):
         # 将组件添加到滚动布局
@@ -760,6 +793,14 @@ class ThemePackSettingDialog(FramelessDialog):
         # 标记有未保存的修改
         self._has_unsaved_changes = True
 
+    def _show_menu_upward(self, button, menu):
+        """Show menu above the button instead of below"""
+        # Anchor the menu to the button's global top-left corner and shift it
+        # upward by the menu height so the whole menu appears above the button.
+        button_pos = button.mapToGlobal(button.rect().topLeft())
+        menu_height = menu.sizeHint().height()
+        menu.exec(button_pos.__class__(button_pos.x(), button_pos.y() - menu_height))
+
     def _on_preferred_threshold_changed(self, value: int):
         """处理优选阈值变化，只更新内存中的配置，不保存到文件"""
         self.config_data["preferred_thresholds"] = int(value)
@@ -835,6 +876,130 @@ class ThemePackSettingDialog(FramelessDialog):
         for card in list(self.normal_cards.values()) + list(self.hard_cards.values()):
             card.update_weight(-5)
         self._has_unsaved_changes = True
+
+    def _extract_team_num_from_path(self) -> int:
+        """Extract team number from save_path"""
+        match = re.search(r'team_(\d+)', self.save_path)
+        if match:
+            return int(match.group(1))
+        return 0
+
+    def on_export_settings(self):
+        """Export theme pack weight to YAML file"""
+        if not self.is_team_specific:
+            return
+
+        team_num = self._extract_team_num_from_path()
+        default_filename = generate_theme_pack_export_filename(team_num)
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            self.tr("导出主题包权重"),
+            default_filename,
+            "YAML Files (*.yaml *.yml)"
+        )
+
+        if file_path:
+            # Save current config first to ensure export gets latest data
+            theme_list.save_config(path=self.save_path, config_data=self.config_data)
+
+            success = export_theme_pack_weight(team_num, file_path)
+            if success:
+                BaseInfoBar.success(
+                    title=self.tr("导出成功"),
+                    content=self.tr("主题包权重已导出到: ") + file_path,
+                    orient=Qt.Orientation.Horizontal,
+                    isClosable=True,
+                    position=InfoBarPosition.TOP,
+                    duration=3000,
+                    parent=self
+                )
+            else:
+                BaseInfoBar.error(
+                    title=self.tr("导出失败"),
+                    content=self.tr("无法导出主题包权重，请检查日志"),
+                    orient=Qt.Orientation.Horizontal,
+                    isClosable=True,
+                    position=InfoBarPosition.TOP,
+                    duration=3000,
+                    parent=self
+                )
+
+    def on_import_settings(self):
+        """Import theme pack weight from YAML file"""
+        if not self.is_team_specific:
+            return
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("导入主题包权重"),
+            "",
+            "YAML Files (*.yaml *.yml)"
+        )
+
+        if not file_path:
+            return
+
+        # Show confirmation dialog
+        confirm = MessageBoxConfirm(
+            self.tr("确认导入"),
+            self.tr("导入将覆盖当前主题包权重设置，是否继续？"),
+            self.window()
+        )
+
+        if not confirm.exec():
+            return
+
+        team_num = self._extract_team_num_from_path()
+        success = import_theme_pack_weight(file_path, team_num)
+
+        if success:
+            # Reload the config data from file
+            self.config_data.clear()
+            reloaded_config = theme_list.load_config(self.save_path)
+            self.config_data.update(copy.deepcopy(reloaded_config))
+
+            # Update UI to reflect imported data
+            if self.is_cn:
+                normal_imported = reloaded_config.get("theme_pack_list_cn", {})
+                hard_imported = reloaded_config.get("theme_pack_list_hard_cn", {})
+            else:
+                normal_imported = reloaded_config.get("theme_pack_list", {})
+                hard_imported = reloaded_config.get("theme_pack_list_hard", {})
+
+            self.preferred_threshold_spinbox.spin_box.setValue(
+                int(reloaded_config.get("preferred_thresholds", 0))
+            )
+
+            for pack_key, weight in normal_imported.items():
+                if pack_key in self.normal_cards:
+                    self.normal_cards[pack_key].update_weight(weight)
+
+            for pack_key, weight in hard_imported.items():
+                if pack_key in self.hard_cards:
+                    self.hard_cards[pack_key].update_weight(weight)
+
+            self._has_unsaved_changes = False
+
+            BaseInfoBar.success(
+                title=self.tr("导入成功"),
+                content=self.tr("主题包权重已导入并应用"),
+                orient=Qt.Orientation.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
+        else:
+            BaseInfoBar.error(
+                title=self.tr("导入失败"),
+                content=self.tr("无法导入主题包权重，请检查文件格式和日志"),
+                orient=Qt.Orientation.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
 
     def save_and_close(self):
         """保存配置到文件并关闭对话框"""

--- a/app/theme_pack_setting_interface.py
+++ b/app/theme_pack_setting_interface.py
@@ -580,7 +580,7 @@ class ThemePackSettingDialog(FramelessDialog):
 
         self.batch_menu_button.setMenu(self.batch_menu)
 
-        # Connect to show menu upward
+        # 连接以向上显示菜单
         self.batch_menu_button.clicked.connect(lambda: self._show_menu_upward(self.batch_menu_button, self.batch_menu))
 
         # 导入导出按钮（仅队伍特定配置显示）
@@ -794,9 +794,9 @@ class ThemePackSettingDialog(FramelessDialog):
         self._has_unsaved_changes = True
 
     def _show_menu_upward(self, button, menu):
-        """Show menu above the button instead of below"""
-        # Anchor the menu to the button's global top-left corner and shift it
-        # upward by the menu height so the whole menu appears above the button.
+        """在按钮上方而不是下方显示菜单"""
+        # 将菜单锚定到按钮的全局左上角，并向上移动菜单高度
+        # 使整个菜单显示在按钮上方
         button_pos = button.mapToGlobal(button.rect().topLeft())
         menu_height = menu.sizeHint().height()
         menu.exec(button_pos.__class__(button_pos.x(), button_pos.y() - menu_height))
@@ -878,14 +878,14 @@ class ThemePackSettingDialog(FramelessDialog):
         self._has_unsaved_changes = True
 
     def _extract_team_num_from_path(self) -> int:
-        """Extract team number from save_path"""
+        """从保存路径中提取队伍编号"""
         match = re.search(r'team_(\d+)', self.save_path)
         if match:
             return int(match.group(1))
         return 0
 
     def on_export_settings(self):
-        """Export theme pack weight to YAML file"""
+        """导出主题包权重到 YAML 文件"""
         if not self.is_team_specific:
             return
 
@@ -900,7 +900,7 @@ class ThemePackSettingDialog(FramelessDialog):
         )
 
         if file_path:
-            # Save current config first to ensure export gets latest data
+            # 先保存当前配置以确保导出获取最新数据
             theme_list.save_config(path=self.save_path, config_data=self.config_data)
 
             success = export_theme_pack_weight(team_num, file_path)
@@ -926,7 +926,7 @@ class ThemePackSettingDialog(FramelessDialog):
                 )
 
     def on_import_settings(self):
-        """Import theme pack weight from YAML file"""
+        """从 YAML 文件导入主题包权重"""
         if not self.is_team_specific:
             return
 
@@ -940,7 +940,7 @@ class ThemePackSettingDialog(FramelessDialog):
         if not file_path:
             return
 
-        # Show confirmation dialog
+        # 显示确认对话框
         confirm = MessageBoxConfirm(
             self.tr("确认导入"),
             self.tr("导入将覆盖当前主题包权重设置，是否继续？"),
@@ -954,12 +954,12 @@ class ThemePackSettingDialog(FramelessDialog):
         success = import_theme_pack_weight(file_path, team_num)
 
         if success:
-            # Reload the config data from file
+            # 从文件重新加载配置数据
             self.config_data.clear()
             reloaded_config = theme_list.load_config(self.save_path)
             self.config_data.update(copy.deepcopy(reloaded_config))
 
-            # Update UI to reflect imported data
+            # 更新界面以反映导入的数据
             if self.is_cn:
                 normal_imported = reloaded_config.get("theme_pack_list_cn", {})
                 hard_imported = reloaded_config.get("theme_pack_list_hard_cn", {})

--- a/module/config/team_import_export.py
+++ b/module/config/team_import_export.py
@@ -1,0 +1,117 @@
+import datetime
+import re
+from pathlib import Path
+from typing import Optional
+
+from ruamel.yaml import YAML
+from pydantic import ValidationError
+
+from module.config import cfg, theme_list
+from module.config.config_typing import TeamSetting
+from module.logger import log
+
+
+def generate_team_export_filename(team_num: int) -> str:
+    """生成队伍设置导出文件名"""
+    team_setting = cfg.config.teams.get(str(team_num))
+    remark_name = team_setting.remark_name if team_setting else None
+
+    date_str = datetime.date.today().isoformat()
+
+    if remark_name:
+        safe_name = re.sub(r'[<>:"/\\|?*]', '_', remark_name)
+        return f"team_settings_{safe_name}_{date_str}.yaml"
+    else:
+        return f"team_settings_team_{team_num}_{date_str}.yaml"
+
+
+def export_team_settings(team_num: int, file_path: str) -> bool:
+    """导出队伍设置到 YAML 文件"""
+    try:
+        team_setting = cfg.config.teams.get(str(team_num))
+        if not team_setting:
+            log.error(f"队伍 {team_num} 未找到")
+            return False
+
+        yaml = YAML()
+        export_data = team_setting.model_dump()
+
+        # 从导出中排除统计字段和队伍编号
+        stats_fields = ['total_mirror_time_hard', 'mirror_hard_count',
+                       'total_mirror_time_normal', 'mirror_normal_count', 'team_number']
+        for field in stats_fields:
+            export_data.pop(field, None)
+
+        theme_pack_weight_path = theme_list.build_team_weight_path(team_num)
+        if Path(theme_pack_weight_path).exists():
+            with open(theme_pack_weight_path, 'r', encoding='utf-8') as f:
+                theme_pack_data = yaml.load(f)
+                if theme_pack_data:
+                    export_data['custom_theme_pack_weight'] = theme_pack_data
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            yaml.dump(export_data, f)
+
+        log.info(f"已导出队伍 {team_num} 设置到 {file_path}")
+        return True
+    except Exception as e:
+        log.error(f"导出队伍设置失败: {e}")
+        return False
+
+
+def import_team_settings(file_path: str, team_num: int) -> tuple[Optional[TeamSetting], Optional[dict], list[str]]:
+    """从 YAML 文件导入队伍设置
+
+    Args:
+        file_path: 要导入的 YAML 文件路径
+        team_num: 队伍编号（用于上下文，不用于验证）
+
+    Returns:
+        元组 (TeamSetting, theme_pack_weight, missing_fields)
+        - TeamSetting: 解析的队伍设置，如果解析失败则为 None
+        - theme_pack_weight: 自定义主题包权重字典（如果存在），否则为 None
+        - missing_fields: 缺失的必需字段列表，如果所有字段都存在则为空列表
+    """
+    try:
+        yaml = YAML()
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = yaml.load(f)
+
+        if not data:
+            return None, None, ["文件为空"]
+
+        theme_pack_weight = data.pop('custom_theme_pack_weight', None)
+
+        try:
+            team_setting = TeamSetting(**data)
+            return team_setting, theme_pack_weight, []
+        except ValidationError as e:
+            missing_fields = [err['loc'][0] for err in e.errors() if err['type'] == 'missing']
+            if missing_fields:
+                # 使用 model_construct 为缺失字段创建默认值
+                team_setting = TeamSetting.model_construct(**data)
+                return team_setting, theme_pack_weight, missing_fields
+            else:
+                log.error(f"验证错误: {e}")
+                return None, None, [str(e)]
+    except Exception as e:
+        log.error(f"导入队伍设置失败: {e}")
+        return None, None, [str(e)]
+
+
+def apply_team_settings(team_num: int, team_setting: TeamSetting, theme_pack_weight: Optional[dict]) -> None:
+    """应用导入的队伍设置到配置"""
+    cfg.config.teams[str(team_num)] = team_setting
+
+    if theme_pack_weight:
+        theme_pack_weight_path = Path(theme_list.build_team_weight_path(team_num))
+        theme_pack_weight_path.parent.mkdir(parents=True, exist_ok=True)
+
+        yaml = YAML()
+        with open(theme_pack_weight_path, 'w', encoding='utf-8') as f:
+            yaml.dump(theme_pack_weight, f)
+
+        log.info(f"已创建/更新队伍 {team_num} 的主题包权重文件")
+
+    cfg.save()
+    log.info(f"已应用队伍 {team_num} 的设置")

--- a/module/config/theme_pack_import_export.py
+++ b/module/config/theme_pack_import_export.py
@@ -1,0 +1,138 @@
+import datetime
+import re
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from module.config import cfg, theme_list
+from module.logger import log
+
+
+def generate_theme_pack_export_filename(team_num: int) -> str:
+    """生成主题包权重导出文件名
+
+    Args:
+        team_num: 队伍编号
+
+    Returns:
+        格式为 theme_pack_weight_team_{remark_name}_{date}.yaml 的文件名
+        如果没有备注名则为 theme_pack_weight_team_{team_num}_{date}.yaml
+    """
+    team_setting = cfg.config.teams.get(str(team_num))
+    remark_name = team_setting.remark_name if team_setting else None
+
+    date_str = datetime.date.today().isoformat()
+
+    if remark_name:
+        safe_name = re.sub(r'[<>:"/\\|?*]', '_', remark_name)
+        return f"theme_pack_weight_team_{safe_name}_{date_str}.yaml"
+    else:
+        return f"theme_pack_weight_team_{team_num}_{date_str}.yaml"
+
+
+def export_theme_pack_weight(team_num: int, file_path: str) -> bool:
+    """导出主题包权重到 YAML 文件
+
+    Args:
+        team_num: 队伍编号
+        file_path: 导出主题包权重的路径
+
+    Returns:
+        成功返回 True，失败返回 False
+    """
+    try:
+        theme_pack_weight_path = theme_list.build_team_weight_path(team_num)
+
+        if not Path(theme_pack_weight_path).exists():
+            log.error(f"队伍 {team_num} 的主题包权重文件未找到")
+            return False
+
+        yaml = YAML()
+        with open(theme_pack_weight_path, 'r', encoding='utf-8') as f:
+            theme_pack_data = yaml.load(f)
+
+        if not theme_pack_data:
+            log.error(f"队伍 {team_num} 的主题包权重文件为空")
+            return False
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            yaml.dump(theme_pack_data, f)
+
+        log.info(f"已导出队伍 {team_num} 的主题包权重到 {file_path}")
+        return True
+    except Exception as e:
+        log.error(f"导出主题包权重失败: {e}")
+        return False
+
+
+def _deep_merge_dicts(existing: dict, import_data: dict) -> dict:
+    """深度合并字典，将 import_data 合并到 existing
+
+    Args:
+        existing: 现有字典
+        import_data: 要合并的字典
+
+    Returns:
+        合并后的字典
+    """
+    result = existing.copy()
+    for key, value in import_data.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge_dicts(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def import_theme_pack_weight(file_path: str, team_num: int) -> bool:
+    """从 YAML 文件导入主题包权重
+
+    Args:
+        file_path: 要导入的 YAML 文件路径
+        team_num: 队伍编号（用于上下文）
+
+    Returns:
+        成功返回 True，失败返回 False
+    """
+    try:
+        yaml = YAML()
+
+        # 加载导入数据
+        with open(file_path, 'r', encoding='utf-8') as f:
+            import_data = yaml.load(f)
+
+        if not import_data:
+            log.warning(f"队伍 {team_num} 的导入文件为空")
+            return True
+
+        # 加载现有主题包权重或创建空字典
+        theme_pack_weight_path = theme_list.build_team_weight_path(team_num)
+        target_path = Path(theme_pack_weight_path)
+
+        if target_path.exists():
+            with open(theme_pack_weight_path, 'r', encoding='utf-8') as f:
+                existing_data = yaml.load(f)
+                if not existing_data:
+                    existing_data = {}
+        else:
+            existing_data = {}
+
+        # 从导入中合并/替换条目
+        if isinstance(import_data, dict):
+            existing_data = _deep_merge_dicts(existing_data, import_data)
+        else:
+            log.error(f"队伍 {team_num} 的导入数据不是字典")
+            return False
+
+        # 确保父目录存在
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # 保存回 theme_pack_weight_team_{team_num}.yaml
+        with open(theme_pack_weight_path, 'w', encoding='utf-8') as f:
+            yaml.dump(existing_data, f)
+
+        log.info(f"已从 {file_path} 导入队伍 {team_num} 的主题包权重")
+        return True
+    except Exception as e:
+        log.error(f"导入主题包权重失败: {e}")
+        return False


### PR DESCRIPTION
## 🎯 目的 (Purpose)

实现队伍配置和主题包权重的导入导出功能，优化用户界面交互体验，提升配置管理效率。

## 📝 概述 (Summary)

本 PR 添加了完整的配置导入导出系统，允许用户：
- 导出和导入队伍配置（包括嵌入的主题包权重）
- 独立导出和导入主题包权重配置
- 通过菜单化界面创建新队伍（支持从文件创建）

## 🔧 主要变更 (Key Changes)

### 1. 新增模块

#### `module/config/team_import_export.py`
- ✅ `generate_team_export_filename()`: 生成带日期和队伍名称的导出文件名
- ✅ `export_team_settings()`: 导出队伍设置到 YAML，自动嵌入主题包权重
- ✅ `import_team_settings()`: 从 YAML 导入队伍设置，支持缺失字段的优雅处理
- ✅ `apply_team_settings()`: 应用导入的配置到系统

#### `module/config/theme_pack_import_export.py`
- ✅ `generate_theme_pack_export_filename()`: 生成主题包权重导出文件名
- ✅ `export_theme_pack_weight()`: 导出主题包权重配置
- ✅ `import_theme_pack_weight()`: 导入并深度合并主题包权重
- ✅ `_deep_merge_dicts()`: 递归合并字典，保留现有配置

### 2. UI 改进

#### `app/page_card.py`
**新增功能**:
- ✅ `show_team_creation_menu()`: 显示队伍创建菜单（创建空白 / 从文件创建）
- ✅ `create_team_from_file()`: 从配置文件创建新队伍
  - 自动查找可用队伍槽位（1-20）
  - 显示缺失字段警告
  - 完整的错误处理和用户反馈

#### `app/team_setting_card.py`
**新增功能**:
- ✅ `on_export_settings()`: 导出当前队伍设置
- ✅ `on_import_settings()`: 导入队伍设置并应用
- ✅ 添加"导出设置"和"导入设置"按钮

#### `app/theme_pack_setting_interface.py`
**UI 重构**:
- 🎨 将 UI重组为 5 个可见元素：
  - 批量操作下拉菜单（重置/拉取全局/全部设为-5）
  - 导出按钮（仅队伍特定配置）
  - 导入按钮（仅队伍特定配置）
  - 保存并关闭
  - 关闭

