### PR TITLE
fix: event_chance 在主路径中不递减导致多目标兜底永远无法触发

### DIFF
--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -1119,7 +1119,7 @@ class Mirror:
             if auto.find_element("event/choices_assets.png") and auto.find_element(
                 "event/select_first_option_assets.png"
             ):
-                auto.click_element("event/select_first_option_assets.png", check_gray=True)
+                auto.click_element("event/select_first_option_assets.png")
                 event_chance -= 1
             if auto.find_element("event/perform_the_check_feature_assets.png"):
                 event_handling.decision_event_handling()

--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -1119,7 +1119,8 @@ class Mirror:
             if auto.find_element("event/choices_assets.png") and auto.find_element(
                 "event/select_first_option_assets.png"
             ):
-                auto.click_element("event/select_first_option_assets.png")
+                auto.click_element("event/select_first_option_assets.png", check_gray=True)
+                event_chance -= 1
             if auto.find_element("event/perform_the_check_feature_assets.png"):
                 event_handling.decision_event_handling()
             if auto.click_element("event/continue_assets.png"):


### PR DESCRIPTION
在 click select_first_option 后加 event_chance -= 1，
让状态机能从 15 逐渐降到 0 < event_chance < 5 区间，
从而触发多目标匹配点击所有选项的兜底逻辑。否则主路径的
continue 始终跳过 event_chance 状态机，多目标 fallback 永无执行机会。

关联：#625
（并未较为优雅的修复，但是可以解决在这卡死的问题。