### PR TITLE
修复镜牢编队队列状态归一化及编队删除/重启崩溃链

### DIFF
--- a/app/base_tools.py
+++ b/app/base_tools.py
@@ -175,26 +175,8 @@ class BaseCheckBox(BaseLayout):
                 checked = 2 * checked
             cfg.set_value(self.config_name, checked)
         elif self.config_name.startswith("the_team_"):
-            index = int(self.config_name.split("_")[-1]) - 1
-            if checked:
-                cfg.set_value("teams_be_select_num", cfg.get_value("teams_be_select_num") + 1)
-                teams_be_select = cfg.get_value("teams_be_select")
-                teams_be_select[index] = True
-                teams_order = cfg.get_value("teams_order")
-                teams_order[index] = cfg.get_value("teams_be_select_num")
-                cfg.set_value("teams_be_select", teams_be_select)
-                cfg.set_value("teams_order", teams_order)
-            else:
-                cfg.set_value("teams_be_select_num", cfg.get_value("teams_be_select_num") - 1)
-                teams_be_select = cfg.get_value("teams_be_select")
-                teams_be_select[index] = False
-                teams_order = cfg.get_value("teams_order")
-                for i in range(len(teams_order)):
-                    if teams_order[i] > teams_order[index]:
-                        teams_order[i] -= 1
-                teams_order[index] = 0
-                cfg.set_value("teams_be_select", teams_be_select)
-                cfg.set_value("teams_order", teams_order)
+            team_num = int(self.config_name.split("_")[-1])
+            cfg.set_team_enabled(team_num, checked)
             mediator.refresh_teams_order.emit()
         elif self.config_name.startswith("autodaily"):
             mediator.autodaily_setting.emit(self.config_name)

--- a/app/farming_interface.py
+++ b/app/farming_interface.py
@@ -549,11 +549,7 @@ class FarmingInterfaceLeft(QWidget):
             # 检查队伍配置状况
             teams_be_select = sum(1 for team in cfg.teams_be_select if team)
             if teams_be_select != cfg.teams_be_select_num:
-                cfg.set_value("teams_be_select_num", teams_be_select)
-                from utils.utils import check_teams_order
-
-                teams_order = check_teams_order(cfg.teams_order)
-                cfg.set_value("teams_order", teams_order)
+                cfg.normalize_and_sync_team_state()
                 cfg.flush()
 
             if cfg.teams_be_select_num == 0:

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -601,6 +601,7 @@ class PageMirror(PageCard):
 
     def get_setting(self):
         team_toggle_button_group.clear()
+        cfg.normalize_and_sync_team_state(persist=False)
         self.page_general.setUpdatesEnabled(False)
         try:
             for i in range(1, 21):
@@ -636,8 +637,7 @@ class PageMirror(PageCard):
 
             if cfg.config.teams.get(f"{number}", None) is None:
                 cfg.config.teams[f"{number}"] = TeamSetting()
-                cfg.config.teams_be_select.append(False)
-                cfg.config.teams_order.append(0)
+                cfg.normalize_and_sync_team_state()
                 theme_list.create_team_weight_config(number)
                 cfg.save()
 
@@ -660,34 +660,32 @@ class PageMirror(PageCard):
                 team_order_box = team.findChild(BaseCheckBox, f"the_team_{team.team_number}")
                 if team_order_box is not None:
                     team_order_box.set_check_false()
+            number = int(target.split("_")[-1])
             self.remove_team_card(target)
 
-            number = int(target.split("_")[-1])
+            cfg.remove_team_from_queue(number)
             cfg.config.teams.pop(f"{number}", None)
-
-            cfg.config.teams_be_select.pop(number - 1)
-            cfg.config.teams_order.pop(number - 1)
             theme_list.delete_team_weight_config(number)
 
             self.refresh_team_setting_card()
-            cfg.save()
-
-            self.retranslateUi()
         except Exception as e:
             log.error(f"delete_team 出错：{e}")
 
     def refresh_team_setting_card(self):
-        save_index = 1
-        sorted_indexes = sorted(cfg.config.teams.copy(), key=lambda k: int(k))
-        for index in sorted_indexes:
-            if int(index) == save_index:
-                save_index += 1
-                continue
-            cfg.config.teams[f"{save_index}"] = cfg.config.teams[f"{index}"]
-            del cfg.config.teams[f"{index}"]
-            theme_list.set_team_weight_config_from_team(i, i + 1)
-            theme_list.delete_team_weight_config(i + 1)
-            save_index += 1
+        old_to_new = {}
+        compact_teams = {}
+        for new_index, old_index in enumerate(sorted(cfg.config.teams, key=lambda k: int(k)), start=1):
+            old_number = int(old_index)
+            old_to_new[old_number] = new_index
+            team_setting = cfg.config.teams[old_index]
+            team_setting.team_number = new_index
+            compact_teams[f"{new_index}"] = team_setting
+            if new_index != old_number:
+                theme_list.set_team_weight_config_from_team(new_index, old_number)
+                theme_list.delete_team_weight_config(old_number)
+
+        cfg.config.teams = compact_teams
+        cfg.reindex_team_queue(old_to_new)
 
         cfg.save()
         self.get_setting()
@@ -697,8 +695,9 @@ class PageMirror(PageCard):
         teams_order = cfg.config.teams_order
         for team in mirror_teams:
             number = team.team_number
-            if teams_order[number - 1] != 0:
-                team.order.setText(str(teams_order[number - 1]))
+            idx = number - 1
+            if idx < len(teams_order) and teams_order[idx] != 0:
+                team.order.setText(str(teams_order[idx]))
             else:
                 team.order.setText("")
 

--- a/app/team_setting_card.py
+++ b/app/team_setting_card.py
@@ -472,7 +472,9 @@ class StarlightCard(QFrame):
     def __init__(self, class_name: str, label_text: str, team_num: int, parent=None):
         super().__init__(parent)
         self.team_num: int = int(class_name.split("_")[-1])
-        self.level = cfg.config.teams[str(team_num)].opening_bonus_level[int(class_name.split("_")[-1]) - 1]
+        self.level = 0
+        if team_config := cfg.config.teams.get(str(team_num)):
+            self.level = team_config.opening_bonus_level[self.team_num - 1]
 
         self.label_text = label_text
         self.main_layout = QVBoxLayout(self)

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -201,6 +201,12 @@ class Config(metaclass=SingletonMeta):
                     self._old_version_cfg_upgrade(saved_version, loaded_config)
                 # 使用更新后的配置初始化 Config 对象
                 self.config = ConfigModel(**loaded_config)
+                queue_in_loaded_config = loaded_config.get("teams_active_queue")
+                if queue_in_loaded_config is None:
+                    normalized_queue = self._normalize_team_queue(self.migrate_legacy_team_queue())
+                else:
+                    normalized_queue = self._normalize_team_queue(queue_in_loaded_config)
+                self._sync_legacy_team_state(normalized_queue)
                 # 成功加载后保存当前文件为备份
                 shutil.copy(path, path.with_suffix(".yaml.backup"))
                 self.config.save_count += 1
@@ -235,6 +241,130 @@ class Config(metaclass=SingletonMeta):
             except:
                 value = default
         return value
+
+    def get_team_numbers(self) -> list[int]:
+        teams = self.get_value("teams", {}) or {}
+        team_numbers: list[int] = []
+        for team_key in teams:
+            try:
+                team_num = int(team_key)
+            except (TypeError, ValueError):
+                continue
+            if team_num > 0:
+                team_numbers.append(team_num)
+        return sorted(team_numbers)
+
+    def _sync_team_setting_numbers(self) -> None:
+        teams = self.get_value("teams", {}) or {}
+        for team_key, team_setting in teams.items():
+            try:
+                team_num = int(team_key)
+            except (TypeError, ValueError):
+                continue
+            if team_num <= 0 or not isinstance(team_setting, TeamSetting):
+                continue
+            if team_setting.team_number != team_num:
+                self.unsaved_set_value("team_number", team_num, config_obj=team_setting)
+
+    def _normalize_team_queue(self, queue: list[int]) -> list[int]:
+        valid_team_numbers = set(self.get_team_numbers())
+        normalized_queue: list[int] = []
+        seen: set[int] = set()
+        for team_num in queue or []:
+            if type(team_num) is not int:
+                continue
+            if team_num not in valid_team_numbers or team_num in seen:
+                continue
+            normalized_queue.append(team_num)
+            seen.add(team_num)
+        return normalized_queue
+
+    def migrate_legacy_team_queue(self) -> list[int]:
+        team_numbers = self.get_team_numbers()
+        if not team_numbers:
+            return []
+
+        teams_order = self.get_value("teams_order", []) or []
+        order_pairs: list[tuple[int, int]] = []
+        used_orders: set[int] = set()
+        for team_num in team_numbers:
+            order_index = team_num - 1
+            if order_index >= len(teams_order):
+                continue
+            order = teams_order[order_index]
+            if not isinstance(order, int) or order <= 0 or order in used_orders:
+                continue
+            order_pairs.append((order, team_num))
+            used_orders.add(order)
+
+        teams_be_select = self.get_value("teams_be_select", []) or []
+        migrated_queue = [team_num for _, team_num in sorted(order_pairs)]
+        queued_team_numbers = set(migrated_queue)
+        for team_num in team_numbers:
+            select_index = team_num - 1
+            if select_index >= len(teams_be_select):
+                continue
+            if teams_be_select[select_index] is not True or team_num in queued_team_numbers:
+                continue
+            migrated_queue.append(team_num)
+        return migrated_queue
+
+    def _sync_legacy_team_state(self, queue: list[int]) -> None:
+        self._sync_team_setting_numbers()
+        max_team_num = max(self.get_team_numbers(), default=0)
+        teams_be_select = [False] * max_team_num
+        teams_order = [0] * max_team_num
+        for order, team_num in enumerate(queue, start=1):
+            if team_num <= 0 or team_num > max_team_num:
+                continue
+            teams_be_select[team_num - 1] = True
+            teams_order[team_num - 1] = order
+
+        self.unsaved_set_value("teams_active_queue", queue)
+        self.unsaved_set_value("teams_be_select", teams_be_select)
+        self.unsaved_set_value("teams_order", teams_order)
+        self.unsaved_set_value("teams_be_select_num", len(queue))
+
+    def normalize_and_sync_team_state(self, persist: bool = True) -> None:
+        queue = self.get_value("teams_active_queue")
+        if queue is None:
+            queue = self._normalize_team_queue(self.migrate_legacy_team_queue())
+        else:
+            queue = self._normalize_team_queue(queue)
+        self._sync_legacy_team_state(queue)
+        if persist:
+            self.save()
+
+    def reindex_team_queue(self, old_to_new: dict[int, int]) -> None:
+        queue = []
+        for team_num in self.get_value("teams_active_queue", []) or []:
+            new_team_num = old_to_new.get(team_num)
+            if isinstance(new_team_num, int):
+                queue.append(new_team_num)
+        self._sync_legacy_team_state(self._normalize_team_queue(queue))
+        self.save()
+
+    def rotate_team_queue(self) -> None:
+        queue = self._normalize_team_queue(self.get_value("teams_active_queue", []))
+        if len(queue) > 1:
+            queue = queue[1:] + queue[:1]
+        self._sync_legacy_team_state(queue)
+        self.save()
+
+    def remove_team_from_queue(self, team_num: int) -> None:
+        queue = [value for value in self.get_value("teams_active_queue", []) or [] if value != team_num]
+        self._sync_legacy_team_state(self._normalize_team_queue(queue))
+        self.save()
+
+    def set_team_enabled(self, team_num: int, enabled: bool) -> None:
+        queue = self._normalize_team_queue(self.get_value("teams_active_queue", []))
+        if enabled:
+            if team_num not in queue:
+                queue.append(team_num)
+        else:
+            queue = [value for value in queue if value != team_num]
+        self._sync_legacy_team_state(self._normalize_team_queue(queue))
+        self.save()
 
     def set_value(self, key: str, value: Any, *, config_obj: Optional[BaseModel | dict] = None) -> None:
         """设置配置项的值并延迟保存"""
@@ -312,6 +442,12 @@ class Config(metaclass=SingletonMeta):
                 loaded_config = self.yaml.load(file)
             if loaded_config:
                 self.config = ConfigModel(**loaded_config)
+                queue_in_loaded_config = loaded_config.get("teams_active_queue")
+                if queue_in_loaded_config is None:
+                    normalized_queue = self._normalize_team_queue(self.migrate_legacy_team_queue())
+                else:
+                    normalized_queue = self._normalize_team_queue(queue_in_loaded_config)
+                self._sync_legacy_team_state(normalized_queue)
         except FileNotFoundError:
             self._schedule_save()
         except Exception as e:

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -511,6 +511,9 @@ class ConfigModel(BaseModel):
     teams_order: List[int] = [0]
     """队伍的顺序"""
 
+    teams_active_queue: List[int] = []
+    """镜牢启用队伍的执行队列（单一事实源）"""
+
     mirror_keyboard_navigation: bool = False
     """使用键盘进行镜牢寻路"""
 

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -234,6 +234,7 @@ def Mirror_task():
     mediator.mirror_signal.emit(0, mir_times)
     # 开始执行镜牢任务
     while mir_times > 0:
+        cfg.normalize_and_sync_team_state(persist=False)
         # 检测配置的队伍能否顺利执行
         useful = False
         hard = bool(cfg.hard_mirror)
@@ -252,34 +253,22 @@ def Mirror_task():
         if useful is False:
             break
 
-        teams_order = cfg.teams_order  # 复制一份队伍顺序
-        team_num = teams_order.index(1)  # 获取序号1的队伍在队伍顺序中的位置
-        team_setting = cfg.config.teams[f"{team_num + 1}"]  # 获取序号1的队伍的配置
-        # 如果该队伍固定了用途，且不用途符合当前情况，将序号1的队伍移动到队伍顺序的最后
+        if not cfg.teams_active_queue:
+            break
+
+        team_num = cfg.teams_active_queue[0]
+        team_setting = cfg.config.teams[f"{team_num}"]
+        # 如果该队伍固定了用途，且用途不符合当前情况，将队首队伍轮转到队尾
         if team_setting.fixed_team_use:
             if (team_setting.fixed_team_use_select == 0 and not cfg.hard_mirror) or (
                 team_setting.fixed_team_use_select == 1 and cfg.hard_mirror
             ):
-                for index, value in enumerate(teams_order):
-                    if value == 0:
-                        continue
-                    if teams_order[index] == 1:
-                        teams_order[index] = cfg.teams_be_select_num
-                    elif teams_order[index] != 0:
-                        teams_order[index] -= 1
-                cfg.set_value("teams_order", teams_order)
+                cfg.rotate_team_queue()
                 continue
         # 执行一次镜牢任务，根据执行结果进行处理
-        mirror_result = onetime_mir_process(team_setting, int(team_num + 1))
+        mirror_result = onetime_mir_process(team_setting, team_num)
         if mirror_result:
-            for index, value in enumerate(teams_order):
-                if value == 0:
-                    continue
-                if teams_order[index] == 1:
-                    teams_order[index] = cfg.teams_be_select_num
-                elif teams_order[index] != 0:
-                    teams_order[index] -= 1
-            cfg.set_value("teams_order", teams_order)
+            cfg.rotate_team_queue()
             mir_times -= 1
             if cfg.hard_mirror and cfg.auto_hard_mirror:
                 chance = cfg.hard_mirror_chance - 1


### PR DESCRIPTION
- 将 teams_active_queue 设为镜牢编队启用顺序的单一事实源
- 归一化旧配置中缺失顺序 1、重复顺序、队伍编号漂移和计数不一致
- 切换编队勾选、页面重建/删除、启动前自愈、Mirror_task 轮转改为基于队列逻辑
- page_card: 修复 refresh_team_setting_card 中未定义变量 i 导致的 NameError
- page_card: refresh() 中 teams_order[idx] 越界保护，防止启动崩溃
- team_setting_card: StarlightCard 改用 .get() 防御性读取，防止 KeyError

---
> 此分支改动较大，建议除了常规审阅外加入部分用户实际使用反馈

修复了#626中提到的问题：
1. 编队管理中删除了编号更高的激活队伍时会报错的问题
2. 经过`1.`后配置文件故障导致的主程序无法启动的问题

本地测试结果如下：
- 添加小队无异常
- 删除任意激活小队无异常，激活顺序会正确传递
- 使用关联issue中的错误配置文件（在v1.4.10无法启动）能够正常消除问题并进行自动纠正

技术声明：
- module/config/config.py 里加载后归一化逻辑在两处重复，后续可抽成私有方法统一，本次提交未作修改（感觉没必要了）
- type(team_num) is not int 并非缺陷。当前实现是在刻意排除 bool，与现有测试意图一致；
- 存在少量重复 save() 调度，属于实现噪音，不影响功能正确性。

fix #626 