### PR TITLE
fix(gifts_fusion): 修复体系饰品合成前合成标签被遮盖

### DIFF
--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -670,6 +670,8 @@ class Shop:
         self.enter_fuse()
 
         while True:
+            if list_block := auto.find_element("mirror/shop/gifts_list_block.png", take_screenshot=True):
+                auto.mouse_drag(list_block[0], list_block[1], drag_time=1, dy=-500)
             points = auto.find_element(
                 "mirror/shop/fuse_label.png",
                 find_type="image_with_multiple_targets",


### PR DESCRIPTION
修复体系饰品合成前因为被页面下拉而导致合成标签被遮盖