### PR TITLE
fix: 保留队伍配置中的游戏内编队编号

### DIFF
--- a/app/page_card.py
+++ b/app/page_card.py
@@ -765,7 +765,6 @@ class PageMirror(PageCard):
             old_number = int(old_index)
             old_to_new[old_number] = new_index
             team_setting = cfg.config.teams[old_index]
-            team_setting.team_number = new_index
             compact_teams[f"{new_index}"] = team_setting
             if new_index != old_number:
                 theme_list.set_team_weight_config_from_team(new_index, old_number)

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -204,7 +204,6 @@ class Config(metaclass=SingletonMeta):
                     normalized_queue = self._normalize_team_queue(self.migrate_legacy_team_queue())
                 else:
                     normalized_queue = self._normalize_team_queue(queue_in_loaded_config)
-                self._sync_team_setting_numbers()
                 self._sync_legacy_team_state(normalized_queue)
                 # 成功加载后保存当前文件为备份
                 shutil.copy(path, path.with_suffix(".yaml.backup"))
@@ -253,19 +252,6 @@ class Config(metaclass=SingletonMeta):
             if team_num > 0:
                 team_numbers.append(team_num)
         return sorted(team_numbers)
-
-    def _sync_team_setting_numbers(self) -> None:
-        """同步每个 TeamSetting.team_number 与其字典键一致，防止漂移"""
-        teams = self.get_value("teams", {}) or {}
-        for team_key, team_setting in teams.items():
-            try:
-                team_num = int(team_key)
-            except (TypeError, ValueError):
-                continue
-            if team_num <= 0 or not isinstance(team_setting, TeamSetting):
-                continue
-            if team_setting.team_number != team_num:
-                self.unsaved_set_value("team_number", team_num, config_obj=team_setting)
 
     def _normalize_team_queue(self, queue: list[int]) -> list[int]:
         """去重并过滤无效队伍编号，返回干净的队列"""
@@ -455,7 +441,6 @@ class Config(metaclass=SingletonMeta):
                     normalized_queue = self._normalize_team_queue(self.migrate_legacy_team_queue())
                 else:
                     normalized_queue = self._normalize_team_queue(queue_in_loaded_config)
-                self._sync_team_setting_numbers()
                 self._sync_legacy_team_state(normalized_queue)
         except FileNotFoundError:
             self._schedule_save()

--- a/module/config/team_import_export.py
+++ b/module/config/team_import_export.py
@@ -36,9 +36,9 @@ def export_team_settings(team_num: int, file_path: str) -> bool:
         yaml = YAML()
         export_data = team_setting.model_dump()
 
-        # 从导出中排除统计字段和队伍编号
+        # 从导出中排除统计字段；team_number 表示游戏内编队编号，需要保留。
         stats_fields = ['total_mirror_time_hard', 'mirror_hard_count',
-                       'total_mirror_time_normal', 'mirror_normal_count', 'team_number']
+                       'total_mirror_time_normal', 'mirror_normal_count']
         for field in stats_fields:
             export_data.pop(field, None)
 


### PR DESCRIPTION
修复 37c0cc9ccd760a9b0fd121eae5ec2cdabfe4bd36 中引入的“选择队伍名称”会在启动后重置的 bug