### PR TITLE
fix: 空星光列表时 all_click_level 误算为1

### DIFF
--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -774,7 +774,9 @@ class Mirror:
                             level_one_count += 1
                         elif self.opening_bonus_level[index] == 2:
                             level_two_count += 1
-                if len(click_list) == level_one_count:
+                if len(click_list) == 0:
+                    all_click_level = 0
+                elif len(click_list) == level_one_count:
                     all_click_level = 1
                 elif len(click_list) == level_two_count:
                     all_click_level = 2


### PR DESCRIPTION
## Summary
- Fix all_click_level being incorrectly set to 1 when click_list is empty

## Root Cause
When `choose_opening_bonus=True` but no starlight options (星光1~10) are checked, `click_list` is empty (len=0) and `level_one_count` is also 0. The original check `len(click_list) == level_one_count` evaluates to `0 == 0` (True), causing `all_click_level` to be wrongly set to 1.

This leads to attempting `click_element("level_one_bonus_assets.png")` when no stars are actually selected, which can result in unintended clicks.

## Fix
Add an explicit `len(click_list) == 0` guard before the level_one_count/level_two_count checks to correctly set `all_click_level = 0` when the click list is empty.

## Changes
- `tasks/mirror/mirror.py`: +3 lines, -1 line in `enter_mir_with_star()`