### PR TITLE
feat: 定时任务结束操作新增「退出模拟器」独立选项

### DIFF
--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -1041,14 +1041,17 @@ class AutoDailyView(FlyoutViewBase):
             "autodaily_hibernate",
             "autodaily_shutdown",
             "autodaily_lock",
+            "autodaily_exit_emulator",
         ]
         self.box_exit_game = BaseCheckBox("autodaily_exit_game", None, QT_TRANSLATE_NOOP("BaseCheckBox", "退出游戏"))
+        self.box_exit_emulator = BaseCheckBox("autodaily_exit_emulator", None, QT_TRANSLATE_NOOP("BaseCheckBox", "退出模拟器"))
         self.box_exit_aalc = BaseCheckBox("autodaily_exit_aalc", None, QT_TRANSLATE_NOOP("BaseCheckBox", "退出AALC"))
         self.box_sleep = BaseCheckBox("autodaily_sleep", None, QT_TRANSLATE_NOOP("BaseCheckBox", "睡眠"))
         self.box_hibernate = BaseCheckBox("autodaily_hibernate", None, QT_TRANSLATE_NOOP("BaseCheckBox", "休眠"))
         self.box_shutdown = BaseCheckBox("autodaily_shutdown", None, QT_TRANSLATE_NOOP("BaseCheckBox", "关机"))
         self.box_lock = BaseCheckBox("autodaily_lock", None, QT_TRANSLATE_NOOP("BaseCheckBox", "锁屏"))
         self.line_2.addWidget(self.box_exit_game)
+        self.line_2.addWidget(self.box_exit_emulator)
         self.line_2.addWidget(self.box_exit_aalc)
         self.line_2.addWidget(self.box_sleep)
         self.line_2.addWidget(self.box_hibernate)
@@ -1086,8 +1089,11 @@ class AutoDailyView(FlyoutViewBase):
             self.config_name = self.__search_parent_class().config_name
         self.setting = cfg.get_value(self.config_name + "_task")
         self.exit_setting = cfg.get_value(self.config_name + "_task_exit")
-        if len(self.exit_setting) < 6:
-            self.exit_setting = list(self.exit_setting) + [False] * (6 - len(self.exit_setting))
+        exit_old_len = len(self.exit_setting)
+        if exit_old_len < 7:
+            self.exit_setting = list(self.exit_setting) + [False] * (7 - exit_old_len)
+            if exit_old_len > 0 and self.exit_setting[0]:
+                self.exit_setting[6] = True
 
         task = [
             self.box_daily,
@@ -1104,6 +1110,7 @@ class AutoDailyView(FlyoutViewBase):
             self.box_hibernate,
             self.box_shutdown,
             self.box_lock,
+            self.box_exit_emulator,
         ]
         for i in range(len(exit_task)):
             exit_task[i].set_checked(self.exit_setting[i])
@@ -1126,8 +1133,8 @@ class AutoDailyView(FlyoutViewBase):
             self.exit_setting[index] = not self.exit_setting[index]
 
     def __save(self):
-        if len(self.exit_setting) < 6:
-            self.exit_setting = list(self.exit_setting) + [False] * (6 - len(self.exit_setting))
+        if len(self.exit_setting) < 7:
+            self.exit_setting = list(self.exit_setting) + [False] * (7 - len(self.exit_setting))
         cfg.set_value(self.config_name + "_task", self.setting)
         cfg.set_value(self.config_name + "_task_exit", self.exit_setting)
         # 关闭弹出窗
@@ -1156,6 +1163,7 @@ class AutoDailyView(FlyoutViewBase):
         self.box_buy_enkephalin.retranslateUi()
         self.box_mirror.retranslateUi()
         self.box_exit_game.retranslateUi()
+        self.box_exit_emulator.retranslateUi()
         self.box_exit_aalc.retranslateUi()
         self.box_sleep.retranslateUi()
         self.box_hibernate.retranslateUi()

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -31,19 +31,19 @@ theme_mode: AUTO # 应用主题：AUTO, LIGHT, DARK
 autostart: False # 自启动
 autodaily: False # 启用定时执行
 autodaily_task: [False, False, False, False]
-autodaily_task_exit: [False, False, False, False, False, False]
+autodaily_task_exit: [False, False, False, False, False, False, False]
 autodaily_time: "00:00" # 定时执行时间 (HH:mm)
 autodaily2: False # 启用定时执行2
 autodaily2_task: [False, False, False, False]
-autodaily2_task_exit: [False, False, False, False, False, False]
+autodaily2_task_exit: [False, False, False, False, False, False, False]
 autodaily_time2: "00:00" # 定时执行时间2 (HH:mm)
 autodaily3: False # 启用定时执行3
 autodaily3_task: [False, False, False, False]
-autodaily3_task_exit: [False, False, False, False, False, False]
+autodaily3_task_exit: [False, False, False, False, False, False, False]
 autodaily_time3: "00:00" # 定时执行时间3 (HH:mm)
 autodaily4: False # 启用定时执行4
 autodaily4_task: [False, False, False, False]
-autodaily4_task_exit: [False, False, False, False, False, False]
+autodaily4_task_exit: [False, False, False, False, False, False, False]
 autodaily_time4: "00:00" # 定时执行时间4 (HH:mm)
 minimize_to_tray: False # 最小化到托盘
 after_completion_actions: [] # 脚本结束后的前置动作（可多选）：exit_game/exit_emulator/exit_aalc

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -280,8 +280,8 @@ class ConfigModel(BaseModel):
     autodaily_task: List[bool] = [False] * 4
     """定时任务列表"""
 
-    autodaily_task_exit: List[bool] = [False] * 5
-    """定时任务退出列表"""
+    autodaily_task_exit: List[bool] = [False] * 7
+    """定时任务退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
     autodaily_time: str = "00:00"
     """定时执行时间（HH:mm）"""
@@ -292,8 +292,8 @@ class ConfigModel(BaseModel):
     autodaily2_task: List[bool] = [False] * 4
     """定时任务2列表"""
 
-    autodaily2_task_exit: List[bool] = [False] * 5
-    """定时任务2退出列表"""
+    autodaily2_task_exit: List[bool] = [False] * 7
+    """定时任务2退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
     autodaily_time2: str = "00:00"
     """定时执行时间2（HH:mm）"""
@@ -304,8 +304,8 @@ class ConfigModel(BaseModel):
     autodaily3_task: List[bool] = [False] * 4
     """定时任务3列表"""
 
-    autodaily3_task_exit: List[bool] = [False] * 5
-    """定时任务3退出列表"""
+    autodaily3_task_exit: List[bool] = [False] * 7
+    """定时任务3退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
     autodaily_time3: str = "00:00"
     """定时执行时间3（HH:mm）"""
@@ -316,8 +316,8 @@ class ConfigModel(BaseModel):
     autodaily4_task: List[bool] = [False] * 4
     """定时任务4列表"""
 
-    autodaily4_task_exit: List[bool] = [False] * 5
-    """定时任务4退出列表"""
+    autodaily4_task_exit: List[bool] = [False] * 7
+    """定时任务4退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
     autodaily_time4: str = "00:00"
     """定时执行时间4（HH:mm）"""

--- a/module/system_actions.py
+++ b/module/system_actions.py
@@ -76,15 +76,19 @@ def set_after_completion_config(actions: Iterable[str] | None, power_action: str
 
 def autodaily_exit_to_after_completion_config(exit_setting: list[bool] | tuple[bool, ...]) -> tuple[list[str], str]:
     """
-    将 autodaily_task_exit([exit_game, exit_aalc, sleep, hibernate, shutdown, lock]) 转换为统一动作配置。
+    将 autodaily_task_exit([exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]) 转换为统一动作配置。
     """
     values = list(exit_setting) if isinstance(exit_setting, (list, tuple)) else []
-    while len(values) < 6:
+    original_len = len(values)
+    while len(values) < 7:
         values.append(False)
 
     actions: list[str] = []
     if values[0]:
         actions.append(ACTION_EXIT_GAME)
+        if original_len < 7:
+            actions.append(ACTION_EXIT_EMULATOR)
+    if original_len >= 7 and values[6]:
         actions.append(ACTION_EXIT_EMULATOR)
     if values[1]:
         actions.append(ACTION_EXIT_AALC)


### PR DESCRIPTION
## Summary

将 `exit_emulator`（退出模拟器）从 `exit_game`（退出游戏）的硬编码联动中分离为独立选项，允许模拟器用户选择**只关闭游戏不关闭模拟器**。

## 变更说明

- **`module/config/config_typing.py`**: `autodaily*_task_exit` 默认值从 `[False]*5` 扩展为 `[False]*7`（第 7 元素 = `exit_emulator`），并补充字段注释
- **`module/system_actions.py`**: `autodaily_exit_to_after_completion_config()` 解耦逻辑 — 新配置中 `exit_game` 与 `exit_emulator` 独立判断；旧配置（长度 < 7）保持原有联动行为
- **`app/base_combination.py`**: `AutoDailyView` 新增「退出模拟器」复选框 (`box_exit_emulator`)，`__get_init` 支持旧配置自动迁移（若 `exit_game` 已勾选则同步勾选 `exit_emulator`）
- **`assets/config/config.example.yaml`**: 示例配置数组扩充为 7 元素

## 向后兼容

- 旧 5/6 元素配置首次加载时自动补齐为 7 元素
- 若旧配置中 `exit_game=True`，自动将 `exit_emulator` 设为 `True`，与原行为一致