### PR TITLE
fix(simulator): 修复 MuMu 模拟器启动失败、无限递归和 userStop 递归爆炸

### DIFF
--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -15,6 +15,7 @@ from adbutils import AdbError, adb
 
 from module.config import cfg
 from module.logger import log
+from module.my_error.my_error import userStopError
 from utils.utils import run_as_user
 
 from .. import AbstractInput
@@ -413,6 +414,8 @@ class MumuControl(AbstractInput):
                     return f"{adb_info['adb_host']}:{adb_info['adb_port']}"
                 except Exception:
                     return f"127.0.0.1:{int(self.multi_instance_number) * 32 + 16384}"
+        except userStopError:
+            raise
         except Exception as e:
             if _depth >= _MAX_DEPTH:
                 log.warning(
@@ -459,6 +462,8 @@ class MumuControl(AbstractInput):
             self.load_dll()
             log.debug(f"MUMU模拟器编号{self.multi_instance_number}启动完成")
             self.connect()
+        except userStopError:
+            raise
         except Exception as e:
             log.warning(f"start: 启动过程异常 ({type(e).__name__}: {e}), 触发 fallback 重试")
             self.mumu_control_api_backend()
@@ -485,6 +490,8 @@ class MumuControl(AbstractInput):
             ]
             subprocess.run(command)
             log.debug(f"MUMU模拟器编号{self.multi_instance_number}关闭完成")
+        except userStopError:
+            raise
         except:
             self.mumu_control_api_backend()
             self.stop()
@@ -563,6 +570,8 @@ class MumuControl(AbstractInput):
             log.debug(f"命令执行失败！返回码: {cmd_err.returncode}, 错误输出: {cmd_err.stderr}")
             # 可选：根据业务需求返回默认值或重新抛出
             return False
+        except userStopError:
+            raise
         except Exception as e:
             log.error(f"获取应用保活状态失败：{e}", exc_info=True)  # 记录完整堆栈
             self.mumu_control_api_backend()

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -240,28 +240,40 @@ class MumuControl(AbstractInput):
 
         self.start_game_times = 0
 
+        self.mumu_control_api_backend()
+        if self.exe_path:
+            log.debug(f"MumuControl.__init__: exe_path 已初始化 -> {self.exe_path}")
+        else:
+            log.warning("MumuControl.__init__: exe_path 未初始化, 将由 start() 异常 fallback 重试")
         self.start()
         self.adb_connect()
 
-    def adb_connect(self):
-        # Try to connect
-        for _ in range(3):
+    def adb_connect(self, _depth=0):
+        _ADB_MAX_DEPTH = 3
+        if _depth >= _ADB_MAX_DEPTH:
+            log.error(
+                f"ADB 连接重试次数已耗尽 ({_ADB_MAX_DEPTH}轮), 放弃连接，请检查模拟器 ADB 是否正常开启"
+            )
+            return
+        for attempt in range(3):
+            self.check_stop_requested()
             try:
                 port = self.get_mumu_adb_port()
+                log.debug(f"尝试 ADB 连接 (轮次{_depth+1}/{_ADB_MAX_DEPTH}, 尝试{attempt+1}/3): {port}")
                 msg = adb.connect(port)
-                # Connected to 127.0.0.1:59865
-                # Already connected to 127.0.0.1:59865
                 if "connected" in msg:
                     log.debug(f"成功连接至:{port},连接信息: {msg}")
                     return
-                # bad port number '598265' in '127.0.0.1:598265'
                 elif "bad port" in msg:
-                    log.error(f"连接失败，端口号{port}不正确，可能是拼写错误或不规范")
-            except:
+                    log.error(f"ADB 连接失败，端口号{port}不正确，可能是拼写错误或不规范")
+            except Exception as e:
+                log.debug(f"ADB 连接尝试异常 (轮次{_depth+1}, 尝试{attempt+1}): {type(e).__name__}: {e}")
                 continue
+        self.check_stop_requested()
+        log.warning(f"ADB 连接全部3次尝试失败 (轮次{_depth+1}/{_ADB_MAX_DEPTH})，关闭模拟器并重试启动")
         self.close_simulator()
         self.start()
-        self.adb_connect()
+        self.adb_connect(_depth + 1)
 
     def adb_disconnect(self):
         try:
@@ -342,6 +354,7 @@ class MumuControl(AbstractInput):
                     except:
                         continue
                 if not key:
+                    log.debug("mumu_control_api_backend: 未在注册表中找到任何匹配的MuMu安装项")
                     return None
                 self.install_path = os.path.dirname(winreg.QueryValueEx(key, "DisplayIcon")[0]).strip('"')
                 mumu_version, _ = winreg.QueryValueEx(key, "DisplayVersion")
@@ -354,18 +367,16 @@ class MumuControl(AbstractInput):
                 return None
             # 修改路径，使其指向MuMuManager.exe
             self.exe_path = os.path.join(self.install_path, "MuMuManager.exe")
+            log.debug(f"mumu_control_api_backend: 注册表命中, install_path={self.install_path}, mumu_version={mumu_version}")
             if not os.path.isfile(self.exe_path):
+                log.debug(f"mumu_control_api_backend: exe_path 默认路径不存在 ({self.exe_path}), 尝试 shell 降级")
                 from pathlib import Path
 
                 exe_path = Path(self.exe_path)
-                # 1. 拆分路径为各个组成部分
                 parts = list(exe_path.parts)
-                # 2. 修改倒数第二个部分为 "shell"（确保路径长度足够，避免越界）
                 if len(parts) >= 2:
                     parts[-2] = "shell"
-                # 3. 重新拼接成新路径
-                new_exe_path = Path(*parts)  # 用 * 解包列表为Path的参数
-                # 转换为字符串（可选，若需要字符串路径）
+                new_exe_path = Path(*parts)
                 new_exe_path_str = str(new_exe_path)
                 self.exe_path = new_exe_path_str
                 if not os.path.isfile(self.exe_path):
@@ -373,6 +384,7 @@ class MumuControl(AbstractInput):
                         f"查找MuMuManager.exe失败，路径{self.exe_path}不存在，请检查MuMu模拟器是否安装或是否为特供版本"
                     )
                     return None
+                log.debug(f"mumu_control_api_backend: shell 降级成功, exe_path={self.exe_path}")
 
             def detect_major_version():
                 match = re.match(r"^(\d+)\.", mumu_version)
@@ -381,7 +393,8 @@ class MumuControl(AbstractInput):
 
             self.mumu_version = detect_major_version()
 
-    def get_mumu_adb_port(self, multi_instance_number=None):
+    def get_mumu_adb_port(self, multi_instance_number=None, _depth=0):
+        _MAX_DEPTH = 3
         try:
             if multi_instance_number is None and self.multi_instance_number is None:
                 self.multi_instance_number = 0
@@ -398,11 +411,19 @@ class MumuControl(AbstractInput):
                 adb_info = json.loads(proc.stdout)
                 try:
                     return f"{adb_info['adb_host']}:{adb_info['adb_port']}"
-                except:
+                except Exception:
                     return f"127.0.0.1:{int(self.multi_instance_number) * 32 + 16384}"
-        except:
+        except Exception as e:
+            if _depth >= _MAX_DEPTH:
+                log.warning(
+                    f"get_mumu_adb_port 重试耗尽 ({_MAX_DEPTH}轮)，使用默认端口计算"
+                )
+                return f"127.0.0.1:{int(self.multi_instance_number) * 32 + 16384}"
+            log.debug(
+                f"get_mumu_adb_port 异常 (轮次{_depth+1}/{_MAX_DEPTH}): {type(e).__name__}: {e}, 触发 start() 重建后重试"
+            )
             self.start()
-            self.get_mumu_adb_port(self.multi_instance_number)
+            return self.get_mumu_adb_port(multi_instance_number, _depth + 1)
 
     def start(self):
         try:
@@ -429,12 +450,17 @@ class MumuControl(AbstractInput):
             for _ in range(cfg.start_emulator_timeout):
                 time.sleep(1)
                 if self.get_launch_status() == "start_finished":
+                    log.debug("start: 模拟器启动状态确认为 start_finished")
                     break
+            else:
+                log.warning(f"start: 模拟器启动等待超时 ({cfg.start_emulator_timeout}s), 状态可能仍为未启动")
+            self.check_stop_requested()
             self.port = self.get_mumu_adb_port()
             self.load_dll()
             log.debug(f"MUMU模拟器编号{self.multi_instance_number}启动完成")
             self.connect()
-        except:
+        except Exception as e:
+            log.warning(f"start: 启动过程异常 ({type(e).__name__}: {e}), 触发 fallback 重试")
             self.mumu_control_api_backend()
             self.start()
 
@@ -504,6 +530,9 @@ class MumuControl(AbstractInput):
         # 获取应用保活状态
         try:
             log.debug("开始获取应用保活状态")
+            if self.exe_path is None:
+                log.warning("get_app_keptlive: exe_path 为 None, 将触发异常 fallback")
+                raise ValueError("exe_path is None")
             command = f""" "{self.exe_path}" setting -v {self.multi_instance_number} -k app_keptlive"""
             no_window_flag = subprocess.CREATE_NO_WINDOW if hasattr(subprocess, "CREATE_NO_WINDOW") else 0x08000000
             proc = subprocess.run(

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -257,7 +257,6 @@ class MumuControl(AbstractInput):
             )
             return
         for attempt in range(3):
-            self.check_stop_requested()
             try:
                 port = self.get_mumu_adb_port()
                 log.debug(f"尝试 ADB 连接 (轮次{_depth+1}/{_ADB_MAX_DEPTH}, 尝试{attempt+1}/3): {port}")
@@ -270,7 +269,6 @@ class MumuControl(AbstractInput):
             except Exception as e:
                 log.debug(f"ADB 连接尝试异常 (轮次{_depth+1}, 尝试{attempt+1}): {type(e).__name__}: {e}")
                 continue
-        self.check_stop_requested()
         log.warning(f"ADB 连接全部3次尝试失败 (轮次{_depth+1}/{_ADB_MAX_DEPTH})，关闭模拟器并重试启动")
         self.close_simulator()
         self.start()
@@ -457,7 +455,6 @@ class MumuControl(AbstractInput):
                     break
             else:
                 log.warning(f"start: 模拟器启动等待超时 ({cfg.start_emulator_timeout}s), 状态可能仍为未启动")
-            self.check_stop_requested()
             self.port = self.get_mumu_adb_port()
             self.load_dll()
             log.debug(f"MUMU模拟器编号{self.multi_instance_number}启动完成")

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -135,6 +135,10 @@ def init_game():
                     log.info("设置的模拟器端口非常用默认端口，使用默认mumu模拟器")
             elif cfg.mumu_instance_number != -1:
                 mumu_instance_number = cfg.mumu_instance_number
+            log.debug(
+                f"init_game: 模拟器类型=Mumu, 实例编号={mumu_instance_number}, "
+                f"simulator_port={cfg.simulator_port}, mumu_instance_number={cfg.mumu_instance_number}"
+            )
             from module.automation.input_handlers.simulator.mumu_control import (
                 MumuControl,
             )

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -220,9 +220,12 @@ def run_as_user(command: list[str], timeout: int = 30):
     task_name = "TempNonAdminTask"
     bat_path = None
 
+    no_window_flag = (
+        subprocess.CREATE_NO_WINDOW if hasattr(subprocess, "CREATE_NO_WINDOW") else 0x08000000
+    )
+
     def run_cmd(cmd: str, ignore_error: bool = False):
         try:
-            # 增加 timeout 防止进程挂起
             res = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=10)
             if res.returncode != 0 and not ignore_error:
                 log.debug(f"命令执行失败: {cmd}\n错误: {res.stderr.strip()}")
@@ -231,41 +234,50 @@ def run_as_user(command: list[str], timeout: int = 30):
             log.debug(f"命令执行超时: {cmd}")
             return None
 
+    def _fallback_launch():
+        log.warning(f"schtasks 方式启动失败，改用 subprocess.Popen 直接启动: {command}")
+        proc = subprocess.Popen(command, creationflags=no_window_flag)
+        log.debug(f"Popen 已发起, pid={proc.pid}")
+
     try:
         # 1. 预清理：强制删除旧任务 (/f)
         run_cmd(f'schtasks /delete /tn "{task_name}" /f', ignore_error=True)
 
         # 2. 创建临时批处理文件
         with tempfile.NamedTemporaryFile(delete=False, suffix=".bat", mode="w", encoding="gbk") as bat:
-            # 使用 @echo off 减少输出，添加 exit 确保批处理退出
             bat.write(f"@echo off\n{subprocess.list2cmdline(command)}\nexit\n")
             bat_path = bat.name
 
         # 3. 创建任务
-        # /f: 强制创建；/rl limited: 确保以受限权限运行（非管理员）
         username = os.environ.get("USERNAME")
         create_cmd = (
             f'schtasks /create /f /tn "{task_name}" /sc once /st 23:59 /ru "{username}" /tr "cmd.exe /c \'{bat_path}\'"'
         )
-        if run_cmd(create_cmd) is None:
-            return False
+        create_result = run_cmd(create_cmd)
+        if create_result is None or create_result.returncode != 0:
+            _fallback_launch()
+            return
 
         # 4. 立即执行任务
         log.debug(f"启动任务: {command}")
-        if run_cmd(f'schtasks /run /tn "{task_name}"') is None:
-            return False
+        run_result = run_cmd(f'schtasks /run /tn "{task_name}"')
+        if run_result is None or run_result.returncode != 0:
+            _fallback_launch()
+            return
 
         # 5. 等待执行 (根据需求调整)
-        # 注意：schtasks /run 是异步的，这里 sleep 是等待程序启动
         sleep(2)
 
     except Exception as e:
-        log.debug(f"任务: {command} 发生异常: {e}")
-        return False
+        log.warning(f"run_as_user schtasks 路径异常 ({type(e).__name__}: {e}), 尝试 Popen 降级")
+        try:
+            proc = subprocess.Popen(command, creationflags=no_window_flag)
+            log.debug(f"run_as_user Popen 降级成功, pid={proc.pid}")
+        except Exception as e2:
+            log.error(f"run_as_user Popen 降级也失败了: {e2}")
     finally:
         # 6. 最终清理
         run_cmd(f'schtasks /delete /tn "{task_name}" /f', ignore_error=True)
-        # 修复点：增加对 bat_path 类型的显式检查
         if isinstance(bat_path, (str, bytes, os.PathLike)) and os.path.exists(bat_path):
             try:
                 os.unlink(bat_path)


### PR DESCRIPTION
## Summary

修复 3 个 Mumu 模拟器相关问题：

### 1. `exe_path = None` 导致 `"None"` 命令错误
- `MumuControl.__init__` 中 `self.exe_path` 初始化为 `None`，但 `self.start()` 立即使用
- 修复：在 `__init__` 中 `self.start()` 之前调用 `mumu_control_api_backend()` 从注册表预初始化路径
- 新增埋点日志：注册表命中路径、exe_path 初始化状态、get_app_keptlive 空值防御

### 2. `run_as_user` schtasks 方案失败缺乏降级
- `schtasks /create /ru` 在完整 Admin token 及特定 Windows 安全配置下被拒
- 修复：schtasks 失败时 fallback 到 `subprocess.Popen` 直连启动
- 新增 `run_cmd` 返回码判断（原只判断超时，现同时判断 `returncode != 0`）

### 3. `adb_connect()` / `get_mumu_adb_port()` 无限递归
- ADB 连接失败时无条件杀模拟器 + 重启 + 递归，无终止条件，导致 launch-shutdown 死循环
- 修复：添加 `_depth` 参数递归深度保护，上限 3 轮，耗尽后优雅退出

### 4. `userStopError` 被 exception handler 吞掉导致递归爆炸
- `start()` 等 4 个函数的 generic `except Exception` 捕获 `userStopError` 后触发递归重试
- 修复：在 generic `except` 前插入 `except userStopError: raise`

## 测试反馈

- 用户 1（schtasks 失败环境）：**"这个版本没问题，模拟器不会异常关闭了，测试了功能也都正常"**
- 用户 2（非标 Mumu 路径 + ADB 正常环境）：**"subprocess.Popen正常启动了"**，ADB 首次连接成功