### PR TITLE
fix(luxcavation): 修复采光副本首通提示误触返回导致死循环

### DIFF
--- a/tasks/daily/luxcavation.py
+++ b/tasks/daily/luxcavation.py
@@ -14,10 +14,12 @@ def EXP_luxcavation(combat_count: int = 1):
             continue
         if auto.find_element("battle/teams_assets.png"):
             break
-        if auto.find_element("home/first_prompt_assets.png", model="clam") and auto.find_element(
-            "home/back_assets.png", model="normal"
+        if (
+            auto.find_element("home/first_prompt_assets.png", model="clam")
+            and auto.find_element("home/back_assets.png", model="normal")
+            and not auto.find_element("luxcavation/exp_enter.png", threshold=0.85)
         ):
-            auto.click_element("home/back_assets.png")
+            auto.key_press("esc")
             continue
         if auto.find_element("luxcavation/exp_enter.png", threshold=0.85, take_screenshot=True):
             if level := auto.find_element("luxcavation/exp_enter.png", find_type="image_with_multiple_targets"):
@@ -86,10 +88,13 @@ def thread_luxcavation(combat_count: int = 1):
             continue
         if auto.find_element("battle/teams_assets.png"):
             break
-        if auto.find_element("home/first_prompt_assets.png", model="clam") and auto.find_element(
-            "home/back_assets.png", model="normal"
+        if (
+            auto.find_element("home/first_prompt_assets.png", model="clam")
+            and auto.find_element("home/back_assets.png", model="normal")
+            and not auto.find_element("luxcavation/thread_enter_assets.png", threshold=0.78)
+            and not auto.find_element("luxcavation/thread_consume.png", threshold=0.85)
         ):
-            auto.click_element("home/back_assets.png")
+            auto.key_press("esc")
             continue
         if auto.click_element("luxcavation/thread_enter_assets.png", threshold=0.78):
             if pos := auto.find_element("luxcavation/thread_consume.png", threshold=0.85, take_screenshot=True):


### PR DESCRIPTION
## 问题

commit 8683da4 修复了 `back_assets.png` 截图完整性（20KB→26KB），副作用是在 720P 新账号环境下，EXP/纽本选关界面上 `first_prompt_assets + back_assets` 同时高匹配，触发了错误的返回点击，形成死循环。

触发条件：新账号（未推完主线） + 720P 分辨率

## 修复

### 1. 添加选关界面防御条件
在 `first_prompt + back` 判断中确认不处于选关界面时才执行返回：
- EXP: `and not find_element("luxcavation/exp_enter.png", threshold=0.85)`
- 纽本: `and not find_element("luxcavation/thread_enter_assets.png") + not find_element("luxcavation/thread_consume.png")`

### 2. 用 ESC 按键替代图片识别点击
`auto.click_element("home/back_assets.png")` → `auto.key_press("esc")`
不受图片资产版本变更影响，更健壮。

## 变更

仅修改 `tasks/daily/luxcavation.py`，16 行净变更。