### PR TITLE
fix(mirror): 优化商店购买与饰品升级稳定性 + OCR 识别增强

### DIFF
--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -58,6 +58,7 @@ _MONEY_OCR_TRANSLATION = str.maketrans(
         "S": "5",
         "G": "6",
         "B": "8",
+        "h": "4",
     }
 )
 

--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -310,7 +310,7 @@ class Shop:
                 system_gift = sort_points(system_gift, complete_count)
                 while system_gift:
                     gift = system_gift.pop(0)
-                    auto.mouse_click(gift[0], gift[1])
+                    auto.mouse_action_with_pos((gift[0], gift[1]), offset=True)
                     sleep(1)
                     while auto.take_screenshot() is None:
                         continue
@@ -329,7 +329,10 @@ class Shop:
                         auto.mouse_click_blank(times=3)
                         continue
                     else:
-                        auto.mouse_click_blank(times=2)
+                        auto.take_screenshot()
+                        if auto.click_element("mirror/road_in_mir/ego_gift_get_confirm_assets.png"):
+                            sleep(0.5)
+                        auto.mouse_click_blank(times=3)
                         sleep(1)
 
             if self.second_system and self.second_system_action[1]:
@@ -342,7 +345,7 @@ class Shop:
                     system_gift = sort_points(system_gift, complete_count)
                     while system_gift:
                         gift = system_gift.pop(0)
-                        auto.mouse_click(gift[0], gift[1])
+                        auto.mouse_action_with_pos((gift[0], gift[1]), offset=True)
                         sleep(1)
                         while auto.take_screenshot() is None:
                             continue
@@ -361,7 +364,10 @@ class Shop:
                             auto.mouse_click_blank(times=3)
                             continue
                         else:
-                            auto.mouse_click_blank(times=2)
+                            auto.take_screenshot()
+                            if auto.click_element("mirror/road_in_mir/ego_gift_get_confirm_assets.png"):
+                                sleep(0.5)
+                            auto.mouse_click_blank(times=3)
                             sleep(1)
 
             if retry() is False:
@@ -369,25 +375,55 @@ class Shop:
 
             my_remaining_money = self._get_cost()
 
-            if my_remaining_money < 0:
-                log.warning("无法读取剩余金钱，跳过本次刷新")
-            elif keyword_refresh_count < self.max_keyword_refresh and my_remaining_money >= 300:
-                auto.mouse_click_blank(times=3)
-                if auto.click_element("mirror/shop/refresh_keyword_assets.png"):
-                    sleep(1)
-                    auto.click_element(
-                        f"mirror/shop/keyword/keyword_{self.system}.png",
-                        take_screenshot=True,
-                    )
-                    auto.click_element("mirror/shop/refresh_keyword_confirm_assets.png")
-                    keyword_refresh_count += 1
-                    auto.mouse_click_blank()
-                    sleep(3)
-                    if retry() is False:
-                        raise self.RestartGame()
-                    if self.skill_replacement and self.replacement < 3:
-                        self.replacement_skill()
-                    continue
+            if keyword_refresh_count < self.max_keyword_refresh:
+                if my_remaining_money < 0 or my_remaining_money >= 300:
+                    auto.mouse_click_blank(times=3)
+                    if auto.click_element("mirror/shop/refresh_keyword_assets.png"):
+                        sleep(1)
+                        auto.click_element(
+                            f"mirror/shop/keyword/keyword_{self.system}.png",
+                            take_screenshot=True,
+                        )
+                        sleep(0.5)
+                        auto.click_element("mirror/shop/refresh_keyword_confirm_assets.png")
+                        for _ in range(3):
+                            if auto.find_element(
+                                "mirror/shop/refresh_keyword_confirm_assets.png",
+                                take_screenshot=True,
+                            ):
+                                log.warning("关键词刷新确认未生效，重试中")
+                                sleep(0.5)
+                                auto.click_element(
+                                    f"mirror/shop/keyword/keyword_{self.system}.png",
+                                    take_screenshot=True,
+                                )
+                                sleep(0.5)
+                                auto.click_element(
+                                    "mirror/shop/refresh_keyword_confirm_assets.png",
+                                    take_screenshot=True,
+                                )
+                            else:
+                                break
+                        keyword_refresh_count += 1
+                        auto.mouse_click_blank()
+                        sleep(3)
+                        if retry() is False:
+                            raise self.RestartGame()
+                        if self.skill_replacement and self.replacement < 3:
+                            self.replacement_skill()
+                        continue
+
+            if normal_refresh_count < self.max_normal_refresh:
+                if my_remaining_money < 0 or my_remaining_money >= 200:
+                    auto.mouse_click_blank(times=3)
+                    if auto.click_element("mirror/shop/refresh_assets.png"):
+                        normal_refresh_count += 1
+                        sleep(3)
+                        if retry() is False:
+                            raise self.RestartGame()
+                        if self.skill_replacement and self.replacement < 3:
+                            self.replacement_skill()
+                        continue
 
             if normal_refresh_count < self.max_normal_refresh and my_remaining_money >= 200:
                 auto.mouse_click_blank(times=3)
@@ -1099,6 +1135,7 @@ class Shop:
         auto.model = "clam"
         system_level_IV = False
         second_system_level_IV = False
+        stale_count = 0
         while True:
             # 自动截图
             if auto.take_screenshot() is None:
@@ -1166,6 +1203,11 @@ class Shop:
             #     continue
 
             if next_gift is False:
+                break
+
+            stale_count += 1
+            if stale_count > 2:
+                log.debug("连续多轮未找到可升级饰品，退出升级模块")
                 break
 
             loop_count -= 1

--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -2,9 +2,12 @@ import os
 from datetime import datetime
 from time import sleep
 
+from PIL import Image
+
 from module.automation import auto
 from module.config import TeamSetting, cfg
 from module.logger import log
+from module.ocr import ocr
 from tasks import all_sinners_name, all_sinners_name_zh, all_systems, system_cn_zh
 from tasks.base.back_init_menu import back_init_menu
 from tasks.base.retry import retry
@@ -41,6 +44,54 @@ def _debug_save_on_failure(money_bbox, ocr_result, in_heal=False):
             except Exception:
                 pass
     log.info(f"[商店调试] OCR失败, 原始结果: {ocr_result}, 坐标: {money_bbox}")
+
+
+_MONEY_OCR_TRANSLATION = str.maketrans(
+    {
+        "O": "0",
+        "o": "0",
+        "D": "0",
+        "Q": "0",
+        "I": "1",
+        "l": "1",
+        "Z": "2",
+        "S": "5",
+        "G": "6",
+        "B": "8",
+    }
+)
+
+
+def _extract_money_from_ocr_texts(texts):
+    if not texts:
+        return None
+
+    cleaned_texts = [text.strip().replace(" ", "").replace(",", "") for text in texts if text]
+    for text in cleaned_texts:
+        if text.isdigit():
+            return int(text)
+
+    for text in cleaned_texts:
+        normalized = text.translate(_MONEY_OCR_TRANSLATION)
+        if normalized.isdigit() and any(ch.isdigit() for ch in normalized):
+            return int(normalized)
+
+    return None
+
+
+def _retry_money_ocr_with_scaled_crop(money_bbox, scale=2):
+    if auto.screenshot is None or money_bbox is None:
+        return []
+
+    try:
+        crop = auto.screenshot.crop(money_bbox)
+        width, height = crop.size
+        resampling = getattr(getattr(Image, "Resampling", Image), "BICUBIC")
+        enlarged = crop.resize((width * scale, height * scale), resample=resampling)
+        result = ocr.run(enlarged)
+        return list(result.txts or [])
+    except Exception:
+        return []
 
 
 class Shop:
@@ -1420,9 +1471,20 @@ class Shop:
             else:
                 money_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/shop/my_money_bbox.png"))
             my_money = auto.get_text_from_screenshot(money_bbox)
-            if my_money:  # 避免非空
-                my_remaining_money = int(my_money[0])
-            if not my_money or not isinstance(my_remaining_money, int):
+            if _is_shop_debug_enabled():
+                _shop_debug_save(f"get_cost_{'heal' if in_heal else 'shop'}_bbox")
+                log.info(f"[商店调试] OCR原始结果: {my_money}, 坐标: {money_bbox}")
+            parsed_money = _extract_money_from_ocr_texts(my_money)
+            if parsed_money is None:
+                scaled_money = _retry_money_ocr_with_scaled_crop(money_bbox, scale=2)
+                if scaled_money:
+                    log.info(f"[商店调试] OCR放大重试结果: {scaled_money}")
+                    parsed_money = _extract_money_from_ocr_texts(scaled_money)
+                    if parsed_money is not None:
+                        my_money = scaled_money
+            if parsed_money is not None:
+                my_remaining_money = parsed_money
+            if parsed_money is None or my_remaining_money < 0:
                 _debug_save_on_failure(money_bbox, my_money, in_heal)
                 log.error("获取剩余金钱失败")
             else:

--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -1,3 +1,5 @@
+import os
+from datetime import datetime
 from time import sleep
 
 from module.automation import auto
@@ -8,6 +10,37 @@ from tasks.base.back_init_menu import back_init_menu
 from tasks.base.retry import retry
 from tasks.mirror import fusion_result, must_be_abandoned, must_purchase
 from utils.image_utils import ImageUtils
+
+
+def _is_shop_debug_enabled():
+    return bool(cfg.get_value("debug_mode", False) and cfg.get_value("debug_shop", False))
+
+
+def _shop_debug_save(step_name):
+    if not _is_shop_debug_enabled():
+        return
+    debug_dir = "logs/shop_debug"
+    os.makedirs(debug_dir, exist_ok=True)
+    ts = datetime.now().strftime("%H%M%S_%f")[:13]
+    if auto.screenshot:
+        auto.screenshot.save(f"{debug_dir}/{ts}_{step_name}.png")
+    log.info(f"[商店调试] {step_name}")
+
+
+def _debug_save_on_failure(money_bbox, ocr_result, in_heal=False):
+    """金钱OCR失败时自动保存截图和裁剪区域，不依赖debug_shop开关。"""
+    debug_dir = "logs/shop_debug"
+    os.makedirs(debug_dir, exist_ok=True)
+    ts = datetime.now().strftime("%H%M%S_%f")[:13]
+    prefix = "heal" if in_heal else "shop"
+    if auto.screenshot is not None:
+        auto.screenshot.save(f"{debug_dir}/{ts}_{prefix}_full.png")
+        if money_bbox is not None:
+            try:
+                auto.screenshot.crop(money_bbox).save(f"{debug_dir}/{ts}_{prefix}_crop.png")
+            except Exception:
+                pass
+    log.info(f"[商店调试] OCR失败, 原始结果: {ocr_result}, 坐标: {money_bbox}")
 
 
 class Shop:
@@ -1379,6 +1412,8 @@ class Shop:
     def _get_cost(self, in_heal=False) -> int:
         """获取当前剩余的经费"""
         my_remaining_money = -1
+        money_bbox = None
+        my_money = None
         try:
             if in_heal:
                 money_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/shop/my_money_heal_bbox.png"))
@@ -1388,9 +1423,11 @@ class Shop:
             if my_money:  # 避免非空
                 my_remaining_money = int(my_money[0])
             if not my_money or not isinstance(my_remaining_money, int):
+                _debug_save_on_failure(money_bbox, my_money, in_heal)
                 log.error("获取剩余金钱失败")
             else:
                 log.debug(f"剩余金钱：{my_remaining_money}")
         except Exception as e:
+            _debug_save_on_failure(money_bbox, my_money, in_heal)
             log.error(f"获取剩余金钱失败：{e}")
         return my_remaining_money

--- a/tests/test_shop_money_ocr.py
+++ b/tests/test_shop_money_ocr.py
@@ -1,0 +1,37 @@
+import types
+import unittest
+from unittest import mock
+
+from PIL import Image
+
+from tasks.mirror.in_shop import _extract_money_from_ocr_texts, _retry_money_ocr_with_scaled_crop
+
+
+class TestShopMoneyOcr(unittest.TestCase):
+    def test_extract_money_accepts_plain_digits(self):
+        self.assertEqual(_extract_money_from_ocr_texts(["285"]), 285)
+
+    def test_extract_money_ignores_unrelated_text_and_uses_later_digits(self):
+        self.assertEqual(_extract_money_from_ocr_texts(["Refres", "285"]), 285)
+
+    def test_extract_money_normalizes_common_digit_confusions(self):
+        self.assertEqual(_extract_money_from_ocr_texts(["G10 "]), 610)
+
+    def test_extract_money_returns_none_for_non_numeric_text(self):
+        self.assertIsNone(_extract_money_from_ocr_texts(["Refres"]))
+
+    @mock.patch("tasks.mirror.in_shop.ocr.run")
+    @mock.patch("tasks.mirror.in_shop.auto")
+    def test_retry_money_ocr_with_scaled_crop_uses_enlarged_crop(self, auto_mock, ocr_run_mock):
+        auto_mock.screenshot = Image.new("RGB", (20, 20), color="black")
+        ocr_run_mock.return_value = types.SimpleNamespace(txts=["610"])
+
+        result = _retry_money_ocr_with_scaled_crop((2, 2, 8, 8), scale=2)
+
+        self.assertEqual(result, ["610"])
+        enlarged_crop = ocr_run_mock.call_args.args[0]
+        self.assertEqual(enlarged_crop.size, (12, 12))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

### 1. 商店金币 OCR 增强（cbe6c0f, c2ba071, ad239ad）
- OCR 失败时自动保存截图和裁剪区域，方便排查
- 修复 OCR 误识别：增加字符映射表（`O→0`, `I→1`, `Z→2`, `h→4` 等）
- OCR 识别失败时放大 2x 重试
- 防止 `hh9` 等 OCR 误读导致 int() 转换崩溃

### 2. 饰品升级防卡死（c82ff38）
- 升级循环增加 `stale_count`，连续 3 轮无进展自动退出，防止无限卡死

### 3. 关键词刷新确认重试（c82ff38）
- 确认按钮点击后最多 3 次检测重试，解决模拟器下点击被游戏吞的问题

### 4. 系统饰品购买防遮挡（c82ff38）
- 使用 `mouse_action_with_pos(offset=True)` 替代 `mouse_click`，增加坐标偏移
- 购买后补充 `ego_gift_get_confirm` 确认点击兜底

PR 仅涉及 `tasks/mirror/in_shop.py` + `tests/test_shop_money_ocr.py`，不包含任何 macOS 平台相关内容。