### PR TITLE
fix(mirror): 优化商店购买与饰品升级稳定性

### DIFF
--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -1,45 +1,16 @@
 from time import sleep
 
+from PIL import Image
+
 from module.automation import auto
 from module.config import TeamSetting, cfg
 from module.logger import log
+from module.ocr import ocr
 from tasks import all_sinners_name, all_sinners_name_zh, all_systems, system_cn_zh
 from tasks.base.back_init_menu import back_init_menu
 from tasks.base.retry import retry
 from tasks.mirror import fusion_result, must_be_abandoned, must_purchase
 from utils.image_utils import ImageUtils
-
-
-def _is_shop_debug_enabled():
-    return bool(cfg.get_value("debug_mode", False) and cfg.get_value("debug_shop", False))
-
-
-def _shop_debug_save(step_name):
-    if not _is_shop_debug_enabled():
-        return
-    debug_dir = "logs/shop_debug"
-    os.makedirs(debug_dir, exist_ok=True)
-    ts = datetime.now().strftime("%H%M%S_%f")[:13]
-    if auto.screenshot:
-        auto.screenshot.save(f"{debug_dir}/{ts}_{step_name}.png")
-    log.info(f"[商店调试] {step_name}")
-
-
-def _debug_save_on_failure(money_bbox, ocr_result, in_heal=False):
-    """金钱OCR失败时自动保存截图和裁剪区域，不依赖debug_shop开关。"""
-    debug_dir = "logs/shop_debug"
-    os.makedirs(debug_dir, exist_ok=True)
-    ts = datetime.now().strftime("%H%M%S_%f")[:13]
-    prefix = "heal" if in_heal else "shop"
-    if auto.screenshot is not None:
-        auto.screenshot.save(f"{debug_dir}/{ts}_{prefix}_full.png")
-        if money_bbox is not None:
-            try:
-                auto.screenshot.crop(money_bbox).save(f"{debug_dir}/{ts}_{prefix}_crop.png")
-            except Exception:
-                pass
-    log.info(f"[商店调试] OCR失败, 原始结果: {ocr_result}, 坐标: {money_bbox}")
-
 
 _MONEY_OCR_TRANSLATION = str.maketrans(
     {
@@ -56,35 +27,6 @@ _MONEY_OCR_TRANSLATION = str.maketrans(
         "h": "4",
     }
 )
-
-
-# E.G.O 饰品升级扫描区域（相对坐标，基于 1080p/2k 样本校准）
-_ENHANCE_SCAN_REGION_REL = {
-    "left": 0.5151,
-    "top": 0.3380,
-    "right": 0.8844,
-    "bottom": 0.7130,
-}
-
-
-def _filter_enhance_gift_scan_points(points, screen_size):
-    if not points or not screen_size:
-        return points
-
-    width, height = screen_size
-    if not width or not height:
-        return points
-
-    left = int(round(_ENHANCE_SCAN_REGION_REL["left"] * width))
-    top = int(round(_ENHANCE_SCAN_REGION_REL["top"] * height))
-    right = int(round(_ENHANCE_SCAN_REGION_REL["right"] * width))
-    bottom = int(round(_ENHANCE_SCAN_REGION_REL["bottom"] * height))
-
-    return [
-        point
-        for point in points
-        if left <= int(point[0]) <= right and top <= int(point[1]) <= bottom
-    ]
 
 
 def _extract_money_from_ocr_texts(texts):
@@ -118,6 +60,34 @@ def _retry_money_ocr_with_scaled_crop(money_bbox, scale=2):
     except Exception:
         return []
 
+
+# E.G.O 饰品升级扫描区域（相对坐标，基于 1080p/2k 样本校准）
+_ENHANCE_SCAN_REGION_REL = {
+    "left": 0.5151,
+    "top": 0.3380,
+    "right": 0.8844,
+    "bottom": 0.7130,
+}
+
+
+def _filter_enhance_gift_scan_points(points, screen_size):
+    if not points or not screen_size:
+        return points
+
+    width, height = screen_size
+    if not width or not height:
+        return points
+
+    left = int(round(_ENHANCE_SCAN_REGION_REL["left"] * width))
+    top = int(round(_ENHANCE_SCAN_REGION_REL["top"] * height))
+    right = int(round(_ENHANCE_SCAN_REGION_REL["right"] * width))
+    bottom = int(round(_ENHANCE_SCAN_REGION_REL["bottom"] * height))
+
+    return [
+        point
+        for point in points
+        if left <= int(point[0]) <= right and top <= int(point[1]) <= bottom
+    ]
 
 class Shop:
     def __init__(self, team_setting: TeamSetting):

--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -226,7 +226,7 @@ class Shop:
                 system_gift = sort_points(system_gift, complete_count)
                 while system_gift:
                     gift = system_gift.pop(0)
-                    auto.mouse_click(gift[0], gift[1])
+                    auto.mouse_action_with_pos((gift[0], gift[1]), offset=True)
                     sleep(1)
                     while auto.take_screenshot() is None:
                         continue
@@ -245,7 +245,10 @@ class Shop:
                         auto.mouse_click_blank(times=3)
                         continue
                     else:
-                        auto.mouse_click_blank(times=2)
+                        auto.take_screenshot()
+                        if auto.click_element("mirror/road_in_mir/ego_gift_get_confirm_assets.png"):
+                            sleep(0.5)
+                        auto.mouse_click_blank(times=3)
                         sleep(1)
 
             if self.second_system and self.second_system_action[1]:
@@ -258,7 +261,7 @@ class Shop:
                     system_gift = sort_points(system_gift, complete_count)
                     while system_gift:
                         gift = system_gift.pop(0)
-                        auto.mouse_click(gift[0], gift[1])
+                        auto.mouse_action_with_pos((gift[0], gift[1]), offset=True)
                         sleep(1)
                         while auto.take_screenshot() is None:
                             continue
@@ -277,7 +280,10 @@ class Shop:
                             auto.mouse_click_blank(times=3)
                             continue
                         else:
-                            auto.mouse_click_blank(times=2)
+                            auto.take_screenshot()
+                            if auto.click_element("mirror/road_in_mir/ego_gift_get_confirm_assets.png"):
+                                sleep(0.5)
+                            auto.mouse_click_blank(times=3)
                             sleep(1)
 
             if retry() is False:
@@ -285,25 +291,55 @@ class Shop:
 
             my_remaining_money = self._get_cost()
 
-            if my_remaining_money < 0:
-                log.warning("无法读取剩余金钱，跳过本次刷新")
-            elif keyword_refresh_count < self.max_keyword_refresh and my_remaining_money >= 300:
-                auto.mouse_click_blank(times=3)
-                if auto.click_element("mirror/shop/refresh_keyword_assets.png"):
-                    sleep(1)
-                    auto.click_element(
-                        f"mirror/shop/keyword/keyword_{self.system}.png",
-                        take_screenshot=True,
-                    )
-                    auto.click_element("mirror/shop/refresh_keyword_confirm_assets.png")
-                    keyword_refresh_count += 1
-                    auto.mouse_click_blank()
-                    sleep(3)
-                    if retry() is False:
-                        raise self.RestartGame()
-                    if self.skill_replacement and self.replacement < 3:
-                        self.replacement_skill()
-                    continue
+            if keyword_refresh_count < self.max_keyword_refresh:
+                if my_remaining_money < 0 or my_remaining_money >= 300:
+                    auto.mouse_click_blank(times=3)
+                    if auto.click_element("mirror/shop/refresh_keyword_assets.png"):
+                        sleep(1)
+                        auto.click_element(
+                            f"mirror/shop/keyword/keyword_{self.system}.png",
+                            take_screenshot=True,
+                        )
+                        sleep(0.5)
+                        auto.click_element("mirror/shop/refresh_keyword_confirm_assets.png")
+                        for _ in range(3):
+                            if auto.find_element(
+                                "mirror/shop/refresh_keyword_confirm_assets.png",
+                                take_screenshot=True,
+                            ):
+                                log.warning("关键词刷新确认未生效，重试中")
+                                sleep(0.5)
+                                auto.click_element(
+                                    f"mirror/shop/keyword/keyword_{self.system}.png",
+                                    take_screenshot=True,
+                                )
+                                sleep(0.5)
+                                auto.click_element(
+                                    "mirror/shop/refresh_keyword_confirm_assets.png",
+                                    take_screenshot=True,
+                                )
+                            else:
+                                break
+                        keyword_refresh_count += 1
+                        auto.mouse_click_blank()
+                        sleep(3)
+                        if retry() is False:
+                            raise self.RestartGame()
+                        if self.skill_replacement and self.replacement < 3:
+                            self.replacement_skill()
+                        continue
+
+            if normal_refresh_count < self.max_normal_refresh:
+                if my_remaining_money < 0 or my_remaining_money >= 200:
+                    auto.mouse_click_blank(times=3)
+                    if auto.click_element("mirror/shop/refresh_assets.png"):
+                        normal_refresh_count += 1
+                        sleep(3)
+                        if retry() is False:
+                            raise self.RestartGame()
+                        if self.skill_replacement and self.replacement < 3:
+                            self.replacement_skill()
+                        continue
 
             if normal_refresh_count < self.max_normal_refresh and my_remaining_money >= 200:
                 auto.mouse_click_blank(times=3)
@@ -1015,6 +1051,7 @@ class Shop:
         auto.model = "clam"
         system_level_IV = False
         second_system_level_IV = False
+        stale_count = 0
         while True:
             # 自动截图
             if auto.take_screenshot() is None:
@@ -1082,6 +1119,11 @@ class Shop:
             #     continue
 
             if next_gift is False:
+                break
+
+            stale_count += 1
+            if stale_count > 2:
+                log.debug("连续多轮未找到可升级饰品，退出升级模块")
                 break
 
             loop_count -= 1

--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -40,7 +40,7 @@ def _extract_money_from_ocr_texts(texts):
 
     for text in cleaned_texts:
         normalized = text.translate(_MONEY_OCR_TRANSLATION)
-        if normalized.isdigit() and any(ch.isdigit() for ch in normalized):
+        if normalized.isdigit():
             return int(normalized)
 
     return None
@@ -53,11 +53,15 @@ def _retry_money_ocr_with_scaled_crop(money_bbox, scale=2):
     try:
         crop = auto.screenshot.crop(money_bbox)
         width, height = crop.size
-        resampling = getattr(getattr(Image, "Resampling", Image), "BICUBIC")
+        try:
+            resampling = Image.Resampling.BICUBIC
+        except AttributeError:
+            resampling = Image.BICUBIC
         enlarged = crop.resize((width * scale, height * scale), resample=resampling)
         result = ocr.run(enlarged)
         return list(result.txts or [])
     except Exception:
+        log.debug("OCR 放大裁剪识别失败", exc_info=True)
         return []
 
 
@@ -370,55 +374,44 @@ class Shop:
 
             my_remaining_money = self._get_cost()
 
-            if keyword_refresh_count < self.max_keyword_refresh:
-                if my_remaining_money < 0 or my_remaining_money >= 300:
-                    auto.mouse_click_blank(times=3)
-                    if auto.click_element("mirror/shop/refresh_keyword_assets.png"):
-                        sleep(1)
-                        auto.click_element(
-                            f"mirror/shop/keyword/keyword_{self.system}.png",
+            if my_remaining_money < 0:
+                log.warning("无法读取剩余金钱，跳过本次刷新")
+            elif keyword_refresh_count < self.max_keyword_refresh and my_remaining_money >= 300:
+                auto.mouse_click_blank(times=3)
+                if auto.click_element("mirror/shop/refresh_keyword_assets.png"):
+                    sleep(1)
+                    auto.click_element(
+                        f"mirror/shop/keyword/keyword_{self.system}.png",
+                        take_screenshot=True,
+                    )
+                    sleep(0.5)
+                    auto.click_element("mirror/shop/refresh_keyword_confirm_assets.png")
+                    for _ in range(3):
+                        if auto.find_element(
+                            "mirror/shop/refresh_keyword_confirm_assets.png",
                             take_screenshot=True,
-                        )
-                        sleep(0.5)
-                        auto.click_element("mirror/shop/refresh_keyword_confirm_assets.png")
-                        for _ in range(3):
-                            if auto.find_element(
+                        ):
+                            log.warning("关键词刷新确认未生效，重试中")
+                            sleep(0.5)
+                            auto.click_element(
+                                f"mirror/shop/keyword/keyword_{self.system}.png",
+                                take_screenshot=True,
+                            )
+                            sleep(0.5)
+                            auto.click_element(
                                 "mirror/shop/refresh_keyword_confirm_assets.png",
                                 take_screenshot=True,
-                            ):
-                                log.warning("关键词刷新确认未生效，重试中")
-                                sleep(0.5)
-                                auto.click_element(
-                                    f"mirror/shop/keyword/keyword_{self.system}.png",
-                                    take_screenshot=True,
-                                )
-                                sleep(0.5)
-                                auto.click_element(
-                                    "mirror/shop/refresh_keyword_confirm_assets.png",
-                                    take_screenshot=True,
-                                )
-                            else:
-                                break
-                        keyword_refresh_count += 1
-                        auto.mouse_click_blank()
-                        sleep(3)
-                        if retry() is False:
-                            raise self.RestartGame()
-                        if self.skill_replacement and self.replacement < 3:
-                            self.replacement_skill()
-                        continue
-
-            if normal_refresh_count < self.max_normal_refresh:
-                if my_remaining_money < 0 or my_remaining_money >= 200:
-                    auto.mouse_click_blank(times=3)
-                    if auto.click_element("mirror/shop/refresh_assets.png"):
-                        normal_refresh_count += 1
-                        sleep(3)
-                        if retry() is False:
-                            raise self.RestartGame()
-                        if self.skill_replacement and self.replacement < 3:
-                            self.replacement_skill()
-                        continue
+                            )
+                        else:
+                            break
+                    keyword_refresh_count += 1
+                    auto.mouse_click_blank()
+                    sleep(3)
+                    if retry() is False:
+                        raise self.RestartGame()
+                    if self.skill_replacement and self.replacement < 3:
+                        self.replacement_skill()
+                    continue
 
             if normal_refresh_count < self.max_normal_refresh and my_remaining_money >= 200:
                 auto.mouse_click_blank(times=3)
@@ -1505,15 +1498,25 @@ class Shop:
     def _get_cost(self, in_heal=False) -> int:
         """获取当前剩余的经费"""
         my_remaining_money = -1
+        money_bbox = None
+        my_money = None
         try:
             if in_heal:
                 money_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/shop/my_money_heal_bbox.png"))
             else:
                 money_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/shop/my_money_bbox.png"))
             my_money = auto.get_text_from_screenshot(money_bbox)
-            if my_money:  # 避免非空
-                my_remaining_money = int(my_money[0])
-            if not my_money or not isinstance(my_remaining_money, int):
+            parsed_money = _extract_money_from_ocr_texts(my_money)
+            if parsed_money is None:
+                scaled_money = _retry_money_ocr_with_scaled_crop(money_bbox, scale=2)
+                if scaled_money:
+                    log.debug(f"OCR 放大重试结果: {scaled_money}")
+                    parsed_money = _extract_money_from_ocr_texts(scaled_money)
+                    if parsed_money is not None:
+                        my_money = scaled_money
+            if parsed_money is not None:
+                my_remaining_money = parsed_money
+            if parsed_money is None or my_remaining_money < 0:
                 log.error("获取剩余金钱失败")
             else:
                 log.debug(f"剩余金钱：{my_remaining_money}")

--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -10,6 +10,115 @@ from tasks.mirror import fusion_result, must_be_abandoned, must_purchase
 from utils.image_utils import ImageUtils
 
 
+def _is_shop_debug_enabled():
+    return bool(cfg.get_value("debug_mode", False) and cfg.get_value("debug_shop", False))
+
+
+def _shop_debug_save(step_name):
+    if not _is_shop_debug_enabled():
+        return
+    debug_dir = "logs/shop_debug"
+    os.makedirs(debug_dir, exist_ok=True)
+    ts = datetime.now().strftime("%H%M%S_%f")[:13]
+    if auto.screenshot:
+        auto.screenshot.save(f"{debug_dir}/{ts}_{step_name}.png")
+    log.info(f"[商店调试] {step_name}")
+
+
+def _debug_save_on_failure(money_bbox, ocr_result, in_heal=False):
+    """金钱OCR失败时自动保存截图和裁剪区域，不依赖debug_shop开关。"""
+    debug_dir = "logs/shop_debug"
+    os.makedirs(debug_dir, exist_ok=True)
+    ts = datetime.now().strftime("%H%M%S_%f")[:13]
+    prefix = "heal" if in_heal else "shop"
+    if auto.screenshot is not None:
+        auto.screenshot.save(f"{debug_dir}/{ts}_{prefix}_full.png")
+        if money_bbox is not None:
+            try:
+                auto.screenshot.crop(money_bbox).save(f"{debug_dir}/{ts}_{prefix}_crop.png")
+            except Exception:
+                pass
+    log.info(f"[商店调试] OCR失败, 原始结果: {ocr_result}, 坐标: {money_bbox}")
+
+
+_MONEY_OCR_TRANSLATION = str.maketrans(
+    {
+        "O": "0",
+        "o": "0",
+        "D": "0",
+        "Q": "0",
+        "I": "1",
+        "l": "1",
+        "Z": "2",
+        "S": "5",
+        "G": "6",
+        "B": "8",
+        "h": "4",
+    }
+)
+
+
+# E.G.O 饰品升级扫描区域（相对坐标，基于 1080p/2k 样本校准）
+_ENHANCE_SCAN_REGION_REL = {
+    "left": 0.5151,
+    "top": 0.3380,
+    "right": 0.8844,
+    "bottom": 0.7130,
+}
+
+
+def _filter_enhance_gift_scan_points(points, screen_size):
+    if not points or not screen_size:
+        return points
+
+    width, height = screen_size
+    if not width or not height:
+        return points
+
+    left = int(round(_ENHANCE_SCAN_REGION_REL["left"] * width))
+    top = int(round(_ENHANCE_SCAN_REGION_REL["top"] * height))
+    right = int(round(_ENHANCE_SCAN_REGION_REL["right"] * width))
+    bottom = int(round(_ENHANCE_SCAN_REGION_REL["bottom"] * height))
+
+    return [
+        point
+        for point in points
+        if left <= int(point[0]) <= right and top <= int(point[1]) <= bottom
+    ]
+
+
+def _extract_money_from_ocr_texts(texts):
+    if not texts:
+        return None
+
+    cleaned_texts = [text.strip().replace(" ", "").replace(",", "") for text in texts if text]
+    for text in cleaned_texts:
+        if text.isdigit():
+            return int(text)
+
+    for text in cleaned_texts:
+        normalized = text.translate(_MONEY_OCR_TRANSLATION)
+        if normalized.isdigit() and any(ch.isdigit() for ch in normalized):
+            return int(normalized)
+
+    return None
+
+
+def _retry_money_ocr_with_scaled_crop(money_bbox, scale=2):
+    if auto.screenshot is None or money_bbox is None:
+        return []
+
+    try:
+        crop = auto.screenshot.crop(money_bbox)
+        width, height = crop.size
+        resampling = getattr(getattr(Image, "Resampling", Image), "BICUBIC")
+        enlarged = crop.resize((width * scale, height * scale), resample=resampling)
+        result = ocr.run(enlarged)
+        return list(result.txts or [])
+    except Exception:
+        return []
+
+
 class Shop:
     def __init__(self, team_setting: TeamSetting):
         self.system = all_systems[team_setting.team_system]  # 队伍体系
@@ -1100,6 +1209,11 @@ class Shop:
                 find_type="image_with_multiple_targets",
             ):
                 gifts = sorted(gifts, key=lambda x: (x[1], x[0]))
+                raw_count = len(gifts)
+                screen_size = auto.screenshot.size if auto.screenshot is not None else None
+                gifts = _filter_enhance_gift_scan_points(gifts, screen_size)
+                if len(gifts) != raw_count:
+                    log.debug(f"升级扫描区域过滤：{raw_count} -> {len(gifts)}")
                 for gift in gifts:
                     if check_enhanced(gift) is False:
                         auto.mouse_click(gift[0], gift[1])


### PR DESCRIPTION
### 变更内容

- **饰品升级防卡死**：升级循环增加 `stale_count`，连续 3 轮无进展自动退出，避免此前用户反馈的升级卡死问题
- **饰品升级扫描区域限定**：通过 `_ENHANCE_SCAN_REGION_REL` 相对坐标过滤扫描点，避免误识别升级区域外的元素
- **关键词刷新确认重试**：点击确认后最多 3 次重试检测，解决模拟器下点击事件被游戏吞的问题
- **系统饰品购买防遮挡**：使用 `mouse_action_with_pos(offset=True)` 增加坐标偏移，补充 `ego_gift_get_confirm` 确认点击兜底
- **OCR 数字校正辅助**：提供 `_MONEY_OCR_TRANSLATION` 字符映射表和 `_extract_money_from_ocr_texts` / `_retry_money_ocr_with_scaled_crop` 辅助函数
- **普通刷新兜底**：关键词刷新不可用时若金钱足够则尝试普通刷新

仅涉及 `tasks/mirror/in_shop.py`。