### PR TITLE
fix: 移除skip_screenshot避免旧帧误判

### DIFF
--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -51,7 +51,7 @@ def back_init_menu(*, allow_restart: bool = True):
             sleep(0.2)
             continue
 
-        if retry(skip_screenshot=True) is False:
+        if retry() is False:
             return False
 
         if auto.click_element("home/window_assets.png") and auto.find_element("home/mail_assets.png", model="normal"):

--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -46,11 +46,6 @@ def back_init_menu(*, allow_restart: bool = True):
 
                 if SimulatorControl.connection_device.check_game_alive() is False:
                     SimulatorControl.connection_device.start_game()
-        # 自动截图
-        if auto.take_screenshot() is None:
-            sleep(0.2)
-            continue
-
         if retry() is False:
             return False
 

--- a/tasks/base/retry.py
+++ b/tasks/base/retry.py
@@ -72,11 +72,10 @@ def check_times(start_time, timeout=90, logs=True):
         return False
 
 
-def retry(skip_screenshot=False):
-    """重试连接
+def retry():
+    """重试连接。
 
-    Args:
-        skip_screenshot: 为 True 时跳过内部截图，复用调用者已有的截图
+    为保证稳定性，retry 内循环始终刷新截图，避免复用旧帧导致误判。
     """
     start_time = time.time()
     saved_hwnd = screen.handle.hwnd
@@ -89,9 +88,8 @@ def retry(skip_screenshot=False):
             start_time = max(start_time, auto.get_restore_time())
         if check_times(start_time):
             return False
-        if not skip_screenshot or auto.screenshot is None:
-            if auto.take_screenshot() is None:
-                continue
+        if auto.take_screenshot() is None:
+            continue
         if auto.find_element("base/connecting_assets.png"):
             continue
         if position := auto.find_element("base/retry_countdown.png"):


### PR DESCRIPTION
删除 #677 中引入的无用代码