### PR TITLE
fix: 修复游戏更新后后台按键消息无效

### DIFF
--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -66,6 +66,32 @@ key_list = {
     "right": win32con.VK_RIGHT,
 }
 
+EXTENDED_KEY_VKS = frozenset(
+    {
+        win32con.VK_UP,
+        win32con.VK_DOWN,
+        win32con.VK_LEFT,
+        win32con.VK_RIGHT,
+        win32con.VK_HOME,
+        win32con.VK_END,
+        win32con.VK_PRIOR,
+        win32con.VK_NEXT,
+        win32con.VK_INSERT,
+        win32con.VK_DELETE,
+        win32con.VK_RCONTROL,
+        win32con.VK_RMENU,
+        win32con.VK_LWIN,
+        win32con.VK_RWIN,
+    }
+)
+
+MESSAGE_KEY_WPARAMS = {
+    win32con.VK_LCONTROL: win32con.VK_CONTROL,
+    win32con.VK_RCONTROL: win32con.VK_CONTROL,
+    win32con.VK_LMENU: win32con.VK_MENU,
+    win32con.VK_RMENU: win32con.VK_MENU,
+}
+
 
 class WinAbstractInput(AbstractInput):
     """输入接口类，定义输入方法的抽象接口
@@ -97,29 +123,18 @@ class WinAbstractInput(AbstractInput):
         Unity 6+ 会校验 scan code 和 extended flag，
         固定 0x00000001 / 0xC0000001 的消息会被忽略。
         """
-        scan = win32api.MapVirtualKey(vk, 0)
-        extended = vk in {
-            win32con.VK_UP,
-            win32con.VK_DOWN,
-            win32con.VK_LEFT,
-            win32con.VK_RIGHT,
-            win32con.VK_HOME,
-            win32con.VK_END,
-            win32con.VK_PRIOR,
-            win32con.VK_NEXT,
-            win32con.VK_INSERT,
-            win32con.VK_DELETE,
-            win32con.VK_RCONTROL,
-            win32con.VK_RMENU,
-            win32con.VK_LWIN,
-            win32con.VK_RWIN,
-        }
+        scan = win32api.MapVirtualKey(vk, 0) & 0xFF
+        extended = vk in EXTENDED_KEY_VKS
         lparam = 1 | (scan << 16)
         if extended:
             lparam |= 1 << 24
         if key_up:
             lparam |= (1 << 30) | (1 << 31)
         return lparam
+
+    @staticmethod
+    def _make_key_wparam(vk: int) -> int:
+        return MESSAGE_KEY_WPARAMS.get(vk, vk)
 
 
 class Input(WinAbstractInput, metaclass=SingletonMeta):
@@ -520,11 +535,12 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
         """
         hwnd = screen.handle.hwnd
         vk = key_list[key.lower()]
+        wparam = self._make_key_wparam(vk)
         lparam = self._make_key_lparam(vk, key_up=False)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, wparam, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, wparam, lparam)
 
     def key_up(self, key: str):
         """键盘按键抬起
@@ -533,11 +549,12 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
         """
         hwnd = screen.handle.hwnd
         vk = key_list[key.lower()]
+        wparam = self._make_key_wparam(vk)
         lparam = self._make_key_lparam(vk, key_up=True)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYUP, wparam, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYUP, wparam, lparam)
 
     def key_press(self, key):
         """一次键盘按键操作
@@ -771,11 +788,12 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         """
         hwnd = screen.handle.hwnd
         vk = key_list[key.lower()]
+        wparam = self._make_key_wparam(vk)
         lparam = self._make_key_lparam(vk, key_up=False)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, wparam, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, wparam, lparam)
 
     def key_up(self, key: str):
         """键盘按键抬起
@@ -784,11 +802,12 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         """
         hwnd = screen.handle.hwnd
         vk = key_list[key.lower()]
+        wparam = self._make_key_wparam(vk)
         lparam = self._make_key_lparam(vk, key_up=True)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYUP, wparam, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYUP, wparam, lparam)
 
     def key_press(self, key):
         """一次键盘按键操作

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -90,6 +90,37 @@ class WinAbstractInput(AbstractInput):
             log.debug("获取鼠标位置失败（可能锁屏），返回 (0, 0)")
             return (0, 0)
 
+    @staticmethod
+    def _make_key_lparam(vk: int, key_up: bool = False) -> int:
+        """构造 WM_KEYDOWN/UP 的正确 lParam。
+
+        Unity 6+ 会校验 scan code 和 extended flag，
+        固定 0x00000001 / 0xC0000001 的消息会被忽略。
+        """
+        scan = win32api.MapVirtualKey(vk, 0)
+        extended = vk in {
+            win32con.VK_UP,
+            win32con.VK_DOWN,
+            win32con.VK_LEFT,
+            win32con.VK_RIGHT,
+            win32con.VK_HOME,
+            win32con.VK_END,
+            win32con.VK_PRIOR,
+            win32con.VK_NEXT,
+            win32con.VK_INSERT,
+            win32con.VK_DELETE,
+            win32con.VK_RCONTROL,
+            win32con.VK_RMENU,
+            win32con.VK_LWIN,
+            win32con.VK_RWIN,
+        }
+        lparam = 1 | (scan << 16)
+        if extended:
+            lparam |= 1 << 24
+        if key_up:
+            lparam |= (1 << 30) | (1 << 31)
+        return lparam
+
 
 class Input(WinAbstractInput, metaclass=SingletonMeta):
     """基于 `pyautogui` 的输入类, 仅支持前台操作"""
@@ -488,11 +519,12 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
             key (str): 按键名称
         """
         hwnd = screen.handle.hwnd
-        lparam = 0x00000001  # 重复次数为1
+        vk = key_list[key.lower()]
+        lparam = self._make_key_lparam(vk, key_up=False)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, key_list[key.lower()], lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, key_list[key.lower()], lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
 
     def key_up(self, key: str):
         """键盘按键抬起
@@ -500,11 +532,12 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
             key (str): 按键名称
         """
         hwnd = screen.handle.hwnd
-        lparam = 0xC0000001  # 转换状态为1（按键释放）
+        vk = key_list[key.lower()]
+        lparam = self._make_key_lparam(vk, key_up=True)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYUP, key_list[key.lower()], lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYUP, key_list[key.lower()], lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
 
     def key_press(self, key):
         """一次键盘按键操作
@@ -737,11 +770,12 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
             key (str): 按键名称
         """
         hwnd = screen.handle.hwnd
-        lparam = 0x00000001  # 重复次数为1
+        vk = key_list[key.lower()]
+        lparam = self._make_key_lparam(vk, key_up=False)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, key_list[key.lower()], lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, key_list[key.lower()], lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYDOWN, vk, lparam)
 
     def key_up(self, key: str):
         """键盘按键抬起
@@ -749,11 +783,12 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
             key (str): 按键名称
         """
         hwnd = screen.handle.hwnd
-        lparam = 0xC0000001  # 转换状态为1（按键释放）
+        vk = key_list[key.lower()]
+        lparam = self._make_key_lparam(vk, key_up=True)
         if self.use_post_message:
-            win32api.PostMessage(hwnd, win32con.WM_KEYUP, key_list[key.lower()], lparam)
+            win32api.PostMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
         else:
-            win32api.SendMessage(hwnd, win32con.WM_KEYUP, key_list[key.lower()], lparam)
+            win32api.SendMessage(hwnd, win32con.WM_KEYUP, vk, lparam)
 
     def key_press(self, key):
         """一次键盘按键操作


### PR DESCRIPTION
## Summary
- Add correct lParam construction for keyboard WM_KEYDOWN and WM_KEYUP messages
- Fix BackgroundInput and WindowMoveInput using hard-coded 0x00000001 / 0xC0000001 values that Unity 6+ now ignores
- Keep the backport minimal: Windows background input fix only, with no Logitech, tests, or other canary-only refactors

## Verification
- uv run python -m py_compile module/automation/input_handlers/input.py
- uv run ruff check module/automation/input_handlers/input.py
- Reviewed git diff upstream/main...HEAD to confirm the PR changes only module/automation/input_handlers/input.py