### PR TITLE
fix: 防止主题无关图错误触发 dark→default 主题翻转

### DIFF
--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -604,8 +604,9 @@ class Automation(metaclass=SingletonMeta):
         if dark_matched and not default_matched:
             path_manager.set_theme("dark", log_stacklevel=additional_stack + 4)
         elif default_matched and not dark_matched:
-            path_manager.set_theme("default", log_stacklevel=additional_stack + 4)
-            path_changed = path_manager.eliminate_dark_paths() or path_changed
+            if dark_results:
+                path_manager.set_theme("default", log_stacklevel=additional_stack + 4)
+                path_changed = path_manager.eliminate_dark_paths() or path_changed
         elif dark_matched and default_matched:
             best_dark = max(r["matchVal"] for r in dark_results if r["matched"])
             best_default = max(r["matchVal"] for r in default_results if r["matched"])

--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -603,10 +603,9 @@ class Automation(metaclass=SingletonMeta):
         path_changed = False
         if dark_matched and not default_matched:
             path_manager.set_theme("dark", log_stacklevel=additional_stack + 4)
-        elif default_matched and not dark_matched:
-            if dark_results:
-                path_manager.set_theme("default", log_stacklevel=additional_stack + 4)
-                path_changed = path_manager.eliminate_dark_paths() or path_changed
+        elif default_matched and dark_results and not dark_matched:
+            path_manager.set_theme("default", log_stacklevel=additional_stack + 4)
+            path_changed = path_manager.eliminate_dark_paths() or path_changed
         elif dark_matched and default_matched:
             best_dark = max(r["matchVal"] for r in dark_results if r["matched"])
             best_default = max(r["matchVal"] for r in default_results if r["matched"])


### PR DESCRIPTION
当一张图片只存在于 default/share 路径（如 `season_assets.png`），
`existing_image_paths` 返回的 `dark_results` 为空。
此时 `_update_path_state_from_match_results` 看到
`default_matched=True`、`dark_matched=False` 就错误判定
当前是 default 主题，淘汰 dark 路径后后续所有 dark 模板匹配
全失败导致卡死。

在 `default_matched and not dark_matched` 分支加 `if dark_results:` 守卫，
只有资产同时存在 dark 和 default 两个版本时，才允许通过匹配结果切换主题。

---

用于修复 #671 中引入的一个问题：`_update_path_state_from_match_results` 函数在命中通用资产而没有 dark 资产时，会将主题翻转为 default。
复现点：切换为暗色模式，执行“奖励领取、狂气换体”等任务，观察到领取完奖励后在主界面发生故障。