### PR TITLE
修复：模拟器模式下避免窗口未初始化刷屏

### DIFF
--- a/module/game_and_screen/screen.py
+++ b/module/game_and_screen/screen.py
@@ -29,7 +29,8 @@ class Handle:
     def hwnd(self) -> int:
         """获取窗口句柄"""
         if self._hwnd == 0:
-            log.warning("窗口未初始化", stacklevel=3)
+            if not cfg.simulator:
+                log.warning("窗口未初始化", stacklevel=3)
         elif not win32gui.IsWindow(self._hwnd):
             log.warning("窗口句柄无效，可能窗口已关闭，重新获取", stacklevel=3)
             self.init_handle()


### PR DESCRIPTION
## 问题现象

在模拟器模式运行时，部分公共流程会读取窗口句柄状态。模拟器输入并不依赖 PC 版 Unity 窗口句柄，但日志会反复输出“窗口未初始化”，影响排查真正的问题。

## 根因

`Handle.hwnd` 在句柄为 0 时总是输出 warning，没有区分 PC 窗口模式和模拟器模式。

## 解决方式

仅在非模拟器模式下保留“窗口未初始化”告警。模拟器模式下继续返回 0，但不再输出这条无意义 warning。

## 验证方式

- `uv run python -m py_compile module/game_and_screen/screen.py`
- 确认本 PR 只修改 `module/game_and_screen/screen.py`

本 PR 由 Codex 辅助整理和实现。
