### PR TITLE
新增：模拟器模式下恢复连接并自动唤醒游戏

### DIFF
--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -68,6 +68,7 @@ simulator_type: 0 # 0:mumu , 10:其他 。TODO:蓝迭 , 雷电 , 夜神 , 逍遥
 simulator_port: 0 # 端口
 mumu_instance_number: -1 # mumu模拟器的实例编号
 start_emulator_timeout: 120 # 启动模拟器超时时间
+adb_reconnect_on_error: True # ADB或minitouch连接失效时自动重连
 
 # 自动更新
 check_update: True

--- a/module/automation/input_handlers/simulator/simulator_control.py
+++ b/module/automation/input_handlers/simulator/simulator_control.py
@@ -1,6 +1,7 @@
 import random
 import re
 from time import sleep, time
+from typing import Callable, TypeVar
 
 import cv2
 import numpy as np
@@ -12,6 +13,8 @@ from module.logger import log
 
 from .. import AbstractInput
 from .pyminitouch import MNTDevice
+
+T = TypeVar("T")
 
 key_list = {
     "a": 29,
@@ -71,8 +74,14 @@ class SimulatorControl(AbstractInput):
     def clean_connect():
         if SimulatorControl.connection_device is None:
             return
-        SimulatorControl.connection_device.simulator_control.stop()
-        SimulatorControl.connection_device.adb_disconnect()
+        try:
+            SimulatorControl.connection_device.simulator_control.stop()
+        except Exception as e:
+            log.debug(f"清理minitouch连接失败: {e}")
+        try:
+            SimulatorControl.connection_device.adb_disconnect()
+        except Exception as e:
+            log.debug(f"断开ADB连接失败: {e}")
         SimulatorControl.connection_device = None
 
     def __init__(self) -> None:
@@ -89,25 +98,83 @@ class SimulatorControl(AbstractInput):
 
         self.get_simulator()
 
-    def start_game(self):
-        if self.simulator_device is None:
-            self.get_simulator()
+    @staticmethod
+    def _is_recoverable_connection_error(error: Exception) -> bool:
+        message = str(error)
+        return isinstance(error, AdbError) or any(
+            marker in message
+            for marker in (
+                "device",
+                "not found",
+                "offline",
+                "closed",
+                "WinError 10054",
+                "sendall",
+                "意外截图",
+                "截图解码失败",
+                "minitouch",
+                "Broken pipe",
+            )
+        )
+
+    def reconnect(self, reason: str) -> bool:
+        if not bool(cfg.get_value("adb_reconnect_on_error", True)):
+            return False
+
+        log.warning(f"检测到模拟器连接失效，正在重建ADB/minitouch连接: {reason}")
         try:
+            if getattr(self, "simulator_control", None) is not None:
+                self.simulator_control.stop()
+        except Exception as e:
+            log.debug(f"停止旧minitouch连接失败: {e}")
+        try:
+            self.adb_disconnect()
+        except Exception as e:
+            log.debug(f"断开旧ADB连接失败: {e}")
+
+        self.simulator_device = None
+        self.simulator_control = None
+        self.simulator_port = None
+        SimulatorControl.connection_device = None
+        sleep(1)
+        self.get_simulator()
+        return True
+
+    def _call_with_reconnect(self, action: str, func: Callable[[], T]) -> T:
+        try:
+            return func()
+        except Exception as e:
+            if not self._is_recoverable_connection_error(e) or not self.reconnect(f"{action}: {e}"):
+                raise
+            log.info(f"模拟器连接已重建，重试操作: {action}")
+            return func()
+
+    def start_game(self):
+        def _start_game():
+            if self.simulator_device is None:
+                self.get_simulator()
             self.simulator_device.app_start(self.game_package_name)
+
+        try:
+            self._call_with_reconnect("启动游戏", _start_game)
         except Exception as e:
             log.error(f"启动游戏失败，失败原因为{str(e)}")
             log.error("启动游戏失败，请确认是否安装了Limbus Company，五秒后将重新尝试启动")
             try:
-                log.debug(f"获取到的应用列表列表：{self.simulator_device.list_packages()}")
+                packages = self._call_with_reconnect("获取应用列表", lambda: self.simulator_device.list_packages())
+                log.debug(f"获取到的应用列表列表：{packages}")
             except Exception as e:
                 log.error(f"获取应用列表失败，失败原因为{str(e)}")
             sleep(5)
-            self.start_game()
+            self._call_with_reconnect("启动游戏", _start_game)
 
     def adb_connect(self):
         # Try to connect
+        port = int(cfg.simulator_port)
+        if port <= 0:
+            raise RuntimeError("其他模拟器需要填写 ADB 端口，例如蓝叠/雷电常见为 5555")
         for _ in range(3):
-            self.simulator_port = f"127.0.0.1:{int(cfg.simulator_port)}"
+            self.simulator_port = f"127.0.0.1:{port}"
             msg = adb.connect(self.simulator_port)
             # Connected to 127.0.0.1:59865
             # Already connected to 127.0.0.1:59865
@@ -130,7 +197,7 @@ class SimulatorControl(AbstractInput):
                 # bad port number '598265' in '127.0.0.1:598265'
                 elif "bad port" in msg:
                     log.error(f"断开连接失败，端口号{self.simulator_port}不正确，可能是拼写错误或不规范")
-        except:
+        except Exception:
             pass
 
     def get_simulator(self):
@@ -191,12 +258,19 @@ class SimulatorControl(AbstractInput):
         raise RuntimeError("无法连接到模拟器设备，原因未知")
 
     def screenshot(self):
-        data = self.simulator_device.shell(["screencap", "-p"], stream=False, encoding=None)
-        if len(data) < 500:
-            log.warning(f"意外截图: {data}")
-        image = np.frombuffer(data, np.uint8)
-        image = cv2.imdecode(image, cv2.IMREAD_COLOR)
-        return image
+        def _screenshot():
+            if self.simulator_device is None:
+                self.get_simulator()
+            data = self.simulator_device.shell(["screencap", "-p"], stream=False, encoding=None)
+            if len(data) < 500:
+                raise RuntimeError(f"意外截图: {data}")
+            image = np.frombuffer(data, np.uint8)
+            image = cv2.imdecode(image, cv2.IMREAD_COLOR)
+            if image is None:
+                raise RuntimeError("截图解码失败")
+            return image
+
+        return self._call_with_reconnect("截图", _screenshot)
 
     def set_pause(self) -> None:
         """
@@ -239,9 +313,13 @@ class SimulatorControl(AbstractInput):
 
         msg = f"点击位置:({x},{y})"
         log.debug(msg)
-        for i in range(times):
-            self.simulator_device.shell(f"input tap {x} {y}")
-            # 多次点击执行很快所以暂停放到循环外
+        def _tap():
+            for _ in range(times):
+                self.simulator_device.shell(f"input tap {x} {y}")
+                # 多次点击执行很快所以暂停放到循环外
+            return True
+
+        self._call_with_reconnect("点击", _tap)
 
         self.wait_pause()
 
@@ -299,7 +377,7 @@ class SimulatorControl(AbstractInput):
             self.get_simulator()
         try:
             cmd = f"input keyevent {key_list[key]}"
-            self.simulator_device.shell(cmd)
+            self._call_with_reconnect("按键", lambda: self.simulator_device.shell(cmd))
         except Exception as e:
             log.error(f"输入失败：{e}")
 
@@ -313,7 +391,7 @@ class SimulatorControl(AbstractInput):
         try:
             # Android 的 input text 需要把空格写成 %s
             send_text = text.replace(" ", "%s")
-            self.simulator_device.shell(["input", "text", send_text])
+            self._call_with_reconnect("输入文本", lambda: self.simulator_device.shell(["input", "text", send_text]))
         except Exception as e:
             log.error(f"输入文本失败：{e}")
 
@@ -351,29 +429,34 @@ class SimulatorControl(AbstractInput):
             pos_x, pos_y = self._scale(x, y)
             pos_x_2, pos_y_2 = self._scale(x + dx, y + dy)
 
-        self.simulator_control.ext_smooth_swipe(
-            [(pos_x, pos_y), (pos_x_2, pos_y_2)],
-            duration=drag_time * 1000 / 10,
-            part=50,
-            no_up=True,
-        )
-        if drag_time * 0.3 > 0.5:
-            sleep(drag_time * 0.3)
-        else:
-            sleep(0.5)
-        self.simulator_control.up()
+        def _drag():
+            self.simulator_control.ext_smooth_swipe(
+                [(pos_x, pos_y), (pos_x_2, pos_y_2)],
+                duration=drag_time * 1000 / 10,
+                part=50,
+                no_up=True,
+            )
+            if drag_time * 0.3 > 0.5:
+                sleep(drag_time * 0.3)
+            else:
+                sleep(0.5)
+            self.simulator_control.up()
+
+        self._call_with_reconnect("滑动", _drag)
 
     def close_current_app(self):
         if self.simulator_device is None:
             self.get_simulator()
-        self.simulator_device.app_stop(self.game_package_name)
+        self._call_with_reconnect("关闭游戏", lambda: self.simulator_device.app_stop(self.game_package_name))
 
     def check_game_alive(self) -> bool:
         """检查游戏是否存活
         Returns:
             bool: True表示游戏存活，False表示游戏未启动或已退出
         """
-        package = self.simulator_device.app_current().package
+        if self.simulator_device is None:
+            self.get_simulator()
+        package = self._call_with_reconnect("检查游戏存活", lambda: self.simulator_device.app_current().package)
         if package != self.game_package_name:
             return False
         return True
@@ -391,4 +474,7 @@ class SimulatorControl(AbstractInput):
         for pos in position:
             position_conversion.append((self.simulator_max_x - pos[1], pos[0]))
 
-        self.simulator_control.swipe(position_conversion, duration=drag_time * 1000)
+        self._call_with_reconnect(
+            "链式滑动",
+            lambda: self.simulator_control.swipe(position_conversion, duration=drag_time * 1000),
+        )

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -352,6 +352,9 @@ class ConfigModel(BaseModel):
     start_emulator_timeout: int = 120
     """启动模拟器超时时间"""
 
+    adb_reconnect_on_error: bool = True
+    """ADB或minitouch连接失效时自动重连"""
+
     check_update: bool = True
     """检查更新"""
 

--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -1,10 +1,9 @@
 from time import sleep
 
 from module.automation import auto
-from module.config import cfg
 from module.decorator.decorator import begin_and_finish_time_log
 from module.logger import log
-from tasks.base.retry import retry
+from tasks.base.retry import click_title_screen_safely, ensure_simulator_game_started, retry
 from tasks.mirror.reward_card import get_reward_card
 
 
@@ -31,21 +30,8 @@ def back_init_menu(*, allow_restart: bool = True):
             auto.model = "clam"
             sleep(1)
             continue
-        if cfg.simulator:
-            if cfg.simulator_type == 0:
-                from module.automation.input_handlers.simulator.mumu_control import (
-                    MumuControl,
-                )
-
-                if MumuControl.connection_device.check_game_alive() is False:
-                    MumuControl.connection_device.start_game()
-            else:
-                from module.automation.input_handlers.simulator.simulator_control import (
-                    SimulatorControl,
-                )
-
-                if SimulatorControl.connection_device.check_game_alive() is False:
-                    SimulatorControl.connection_device.start_game()
+        if ensure_simulator_game_started():
+            continue
         if retry() is False:
             return False
 
@@ -122,7 +108,7 @@ def back_init_menu(*, allow_restart: bool = True):
         if auto.find_element("base/clear_all_caches_assets.png", model="clam"):
             if auto.click_element("base/update_confirm_assets.png"):
                 continue
-            auto.mouse_click_blank()
+            click_title_screen_safely()
             sleep(5)
             continue
 

--- a/tasks/base/retry.py
+++ b/tasks/base/retry.py
@@ -12,6 +12,65 @@ from module.game_and_screen import screen
 from module.logger import log
 from utils.utils import check_game_running
 
+_last_title_screen_tap_time = 0.0
+_last_simulator_alive_check_time = 0.0
+
+
+def ensure_simulator_game_started() -> bool:
+    """模拟器模式下确认游戏仍在前台，不在时尝试拉起游戏。"""
+    global _last_simulator_alive_check_time
+    if not cfg.simulator:
+        return False
+
+    now = time.time()
+    if now - _last_simulator_alive_check_time < 5:
+        return False
+    _last_simulator_alive_check_time = now
+
+    if cfg.simulator_type == 0:
+        from module.automation.input_handlers.simulator.mumu_control import (
+            MumuControl,
+        )
+
+        connection_device = MumuControl.connection_device
+    else:
+        from module.automation.input_handlers.simulator.simulator_control import (
+            SimulatorControl,
+        )
+
+        connection_device = SimulatorControl.connection_device
+
+    if connection_device is None:
+        return False
+
+    if connection_device.check_game_alive():
+        return False
+
+    log.info("检测到游戏未运行或不在前台，尝试自动启动游戏")
+    connection_device.start_game()
+    sleep(3)
+    return True
+
+
+def click_title_screen_safely() -> None:
+    """标题页点击入口，避开账号、清缓存和中间弹窗区域。"""
+    global _last_title_screen_tap_time
+    if not cfg.simulator:
+        auto.mouse_click_blank()
+        return
+
+    now = time.time()
+    if now - _last_title_screen_tap_time < 10:
+        return
+    _last_title_screen_tap_time = now
+
+    height = int(cfg.set_win_size or 1080)
+    width = int(height * 16 / 9)
+    tap_points = ((0.86, 0.80), (0.74, 0.83), (0.91, 0.58))
+    index = int(now // 10) % len(tap_points)
+    x_ratio, y_ratio = tap_points[index]
+    auto.mouse_click(int(width * x_ratio), int(height * y_ratio))
+
 
 def kill_game():
     """关闭游戏"""
@@ -82,6 +141,9 @@ def retry():
     if is_windows:
         saved_hwnd = screen.handle.hwnd
     while True:
+        if ensure_simulator_game_started():
+            start_time = time.time()
+            continue
         if is_windows and screen.handle.hwnd != saved_hwnd:
             # 句柄发生变化则重置初始时间, 以免误判卡死
             saved_hwnd = screen.handle.hwnd
@@ -111,7 +173,7 @@ def retry():
         if auto.find_element("base/clear_all_caches_assets.png", model="clam"):
             if auto.click_element("base/update_confirm_assets.png"):
                 continue
-            auto.mouse_click_blank()
+            click_title_screen_safely()
             continue
         if auto.click_element("base/only_option_assets.png", model="clam"):
             sleep(5)


### PR DESCRIPTION
## 问题现象

模拟器模式下，ADB 或 minitouch 连接短暂失效后，截图、点击、滑动等操作可能直接失败并中断流程。部分模拟器中游戏进程被关闭或退到非游戏前台后，也需要用户手动重新打开游戏。

## 根因

通用模拟器控制层在执行截图、输入、滑动和前台包名检查时，缺少可恢复连接错误的统一重试入口；同时标题页点击仍复用普通空白点击，模拟器环境下不够稳定。

## 解决方式

- 通用模拟器继续使用用户配置的 `simulator_port` 连接 `127.0.0.1:{port}`，不写死端口。
- 当其他模拟器端口未填写或非法时，给出中文提示，例如蓝叠/雷电常见端口为 `5555`。
- 截图、点击、滑动、按键、输入、启动/关闭游戏、检查游戏前台时，遇到可恢复连接错误会重建 ADB/minitouch 并重试一次。
- retry/back_init 流程中，如果检测到游戏未运行或不在前台，会自动拉起游戏。
- 标题页检测到清缓存按钮且无更新确认时，模拟器模式下改为低频点击安全区域，复用原有 `CONNECTING` 等待逻辑。

## 验证

- `uv run python -m py_compile module/automation/input_handlers/simulator/simulator_control.py tasks/base/retry.py tasks/base/back_init_menu.py`
- `uv run ruff check module/automation/input_handlers/simulator/simulator_control.py tasks/base/retry.py tasks/base/back_init_menu.py`

验证环境：蓝蝶模拟器，Android 13，ADB 端口按用户设置为 `5555`。

本 PR 由 Codex 辅助整理和实现。