### PR TITLE
fix: 饰品合成关键词选择后增加等待避免滚动条拖动失效

### DIFF
--- a/tasks/mirror/in_shop.py
+++ b/tasks/mirror/in_shop.py
@@ -892,12 +892,14 @@ class Shop:
                     while auto.take_screenshot() is None:
                         continue
                     if auto.click_element("mirror/shop/fuse_gift_confirm_assets.png", model="normal"):
+                        sleep(0.5)
                         break
             else:
                 if auto.click_element(f"mirror/shop/keyword/keyword_{self.system}.png"):
                     while auto.take_screenshot() is None:
                         continue
                     if auto.click_element("mirror/shop/fuse_gift_confirm_assets.png", model="normal"):
+                        sleep(0.5)
                         break
             if auto.click_element("mirror/shop/fuse_to_select_keyword_assets.png"):
                 continue


### PR DESCRIPTION
## 问题描述

镜牢商店 ego 饰品合成流程中，当饰品数量较多需要滚动时，选择关键词后滚动条拖动会失效（鼠标指针移动但滚动条不跟随），导致后续合成点击位置错位，出现"把高等级体系饰品重新合成为低级饰品"的现象。饰品数量超过需要滑动滚动条时 100% 复现。

## 根因分析

`tasks/mirror/in_shop.py` 中 `enter_fuse()` 在选择关键词并点击确认后，**没有任何等待**就立即返回：

```python
if auto.click_element("mirror/shop/fuse_gift_confirm_assets.png", model="normal"):
    break  # 立即返回，UI 动画可能尚未完成
```

后续 `fuse_system_gifts()` 立即执行 `mouse_drag()` 拖动滚动条，此时关键词选择 UI 仍在收起动画中，初始 `mouseDown` 事件被面板拦截，拖动失效。

同文件的 `_try_keyword_refresh()` 已有正确的等待模式（`sleep(0.5)` + `_wait_for_keyword_refresh_confirm_to_clear()`），说明项目已认识到"关键词相关 UI 关闭后需要等待"，但 `enter_fuse()` 漏掉了这一步。

## 修复方案

在 `enter_fuse()` 两处关键词确认点击后各增加 `sleep(0.5)`，与同文件 `_try_keyword_refresh()` 的等待模式保持一致。

## 影响范围

仅修改 `tasks/mirror/in_shop.py`，2 行新增，无其他改动。

## fix
fix: #720