### PR TITLE
fix: 启动时清除 SSLKEYLOGFILE 环境变量，避免 OpenSSL 崩溃

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,12 @@ import socket
 import sys
 import threading
 
+# 尽早清除 SSLKEYLOGFILE，避免 OpenSSL 在建立 HTTPS 连接时因跨 CRT 边界崩溃。
+# 该变量通常由调试代理（如 Fiddler/Charles/Wireshark）设置，Python 内嵌的 OpenSSL
+# 在 Windows 上不提供 OPENSSL_Applink 符号，一试写文件就会抛错退出。
+# 此处仅清除当前进程的环境变量，不影响系统设置和其他进程。
+_ORIG_SSLKEYLOGFILE = os.environ.pop("SSLKEYLOGFILE", None)
+
 # 将当前工作目录设置为程序所在的目录，确保无论从哪里执行，其工作目录都正确设置为程序本身的位置，避免路径错误。
 os.chdir(
     os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else os.path.dirname(os.path.abspath(__file__))
@@ -29,6 +35,7 @@ except (AttributeError, OSError):
 from app.language_manager import LanguageManager
 from app.my_app import MainWindow
 from module.config import cfg
+from module.logger import log
 
 
 # 获取管理员权限
@@ -82,6 +89,10 @@ def send_args_to_existing_instance(port, args):
 
 
 if __name__ == "__main__":
+    if _ORIG_SSLKEYLOGFILE is not None:
+        log.warning(f"检测到冲突的环境变量 SSLKEYLOGFILE={_ORIG_SSLKEYLOGFILE}，"
+                     f"已在进程内清除，避免 OpenSSL 崩溃")
+
     # 定义一个唯一的端口号（建议选择 1024-65535 之间的随机数）
     APP_PORT = 62333
 


### PR DESCRIPTION
## 问题

当系统环境变量中存在 `SSLKEYLOGFILE`（通常由 Fiddler/Charles/Wireshark 等调试代理设置），
Python 内嵌的 OpenSSL 在建立 HTTPS 连接时会尝试写入密钥日志文件。
由于 Windows 下 OpenSSL 缺少 `OPENSSL_Applink` 符号桥接 CRT 文件操作，会弹出错误并崩溃退出：

> `OPENSSL_Uplink(00007FFB59D5EC60,08): no OPENSSL_Applink`

## 修复

在进程启动时、所有 HTTPS 请求之前，清除当前进程环境中的 `SSLKEYLOGFILE`。

- 仅清除**当前进程**的环境变量，不影响系统设置和其他进程
- 若原值存在，记录 `log.warning` 告知用户冲突原因
- 新增 `from module.logger import log` 导入

## 相关

- 上游 Issue: #721
- FAQ 已有手工删除该变量的文档说明（`FAQ.md` / `FAQ_EN.md`），此 PR 使程序自动处理

## fix
fix: #721