### PR TITLE
⚙️ci: avoid double-archiving build artifacts

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -40,3 +40,4 @@ jobs:
           name: AALC_${{ inputs.version }}
           path: |
             dist/AALC_${{ inputs.version }}.7z
+          archive: false


### PR DESCRIPTION
GitHub Actions natively supports uploading unzipped artifacts starting from Feb 2026.
This PR addresses the current issue where build artifacts are double-archived (resulting in users downloading a `.zip` file that contains a `.7z` file). This update ensures a clean, single-archive delivery.

GitHub Actions 已于 2026 年 2 月开始支援直接上传非 zip 格式的 build artifact。
本 PR 修复了目前 build artifact 会被重复压缩成内涵 `.7z` 的 `.zip` 包的问题。此修复将确保产物正常分发，不再套娃压缩😂