### PR TITLE
 🛠️ fix: 修复小工具窗口中 checkbox 选中状态无法显示的问题

### DIFF
--- a/tasks/tools/infinite_battle.py
+++ b/tasks/tools/infinite_battle.py
@@ -1,14 +1,13 @@
 from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
-    QCheckBox,
     QLabel,
     QPushButton,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import qconfig
+from qfluentwidgets import CheckBox, qconfig
 
 from module.automation import auto
 from module.config import cfg
@@ -139,9 +138,9 @@ class InfiniteBattles(QWidget):
 
         self.start_stop_button = QPushButton(self.tr("开始战斗"))
         self.start_stop_button.clicked.connect(self.toggle_battle)
-        self.defense_box = QCheckBox(self.tr("无限守备"))
-        self.defense_on_turn1_box = QCheckBox(self.tr("第一回合开启守备"))
-        self.not_choose_event_box = QCheckBox(self.tr("不处理事件"))
+        self.defense_box = CheckBox(self.tr("无限守备"))
+        self.defense_on_turn1_box = CheckBox(self.tr("第一回合开启守备"))
+        self.not_choose_event_box = CheckBox(self.tr("不处理事件"))
         button_layout.addWidget(self.start_stop_button)
         button_layout.addWidget(self.defense_box)
         button_layout.addWidget(self.defense_on_turn1_box)

--- a/tasks/tools/production_module.py
+++ b/tasks/tools/production_module.py
@@ -6,14 +6,13 @@ import win32gui
 from PySide6.QtCore import Qt, QThread, Signal
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
-    QCheckBox,
     QLabel,
     QPushButton,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
-from qfluentwidgets import qconfig
+from qfluentwidgets import CheckBox, qconfig
 
 from module.automation import auto
 from module.config import cfg
@@ -233,7 +232,7 @@ class ProductionModule(QWidget):
         self.start_stop_button = QPushButton(self.start_msg)
         self.start_stop_button.clicked.connect(self.toggle_production)
         self.box_msg = self.tr("等待期间关闭游戏")
-        self.kill_game_box = QCheckBox(self.box_msg)
+        self.kill_game_box = CheckBox(self.box_msg)
         button_layout.addWidget(self.start_stop_button)
         button_layout.addWidget(self.kill_game_box)
 


### PR DESCRIPTION
## 问题描述

  "小工具"中的多个 checkbox 点击后看不出选中状态，勾选前后渲染结果完全一致，导致用户无法确认这些开关是否已生效：

  - 自动战斗窗口：`无限守备` / `第一回合开启守备` / `不处理事件`
  - 自动换饼窗口：`等待期间关闭游戏`

<img width="1200" height="858" alt="image" src="https://github.com/user-attachments/assets/09938316-30eb-4875-98d7-ad16d7c4d1ee" />
<p align="center">
  <em>如图，自动战斗里的这三个 checkbox 不论选中与否都是空白的</em>
</p>

## 问题分析

  `tasks/tools/ui_style.py` 里给 `QCheckBox` 设置了 QSS：

  ```css
  QCheckBox {
      background-color: transparent;
      color: {window_fg};
  }
  ```

Qt 只要给 `QCheckBox` 加了任何 QSS，就会切换成样式表模式渲染整个控件（包括 indicator 子控件）。但这里没写 `::indicator` / `::indicator:checked` 的样式，所以选中和未选中的 indicator 看起来完全一样。

## 修复方案

将这几个工具窗口里的 `QCheckBox` 替换为 `qfluentwidgets.CheckBox`（主界面其他地方使用的同一控件）。`qfluentwidgets.CheckBox` 自行 `paintEvent` 绘制选中态，不依赖外部 QSS 的 `::indicator` 规则，因此不受 `ui_style.py` 整体 QSS 影响。此法亦可使选中状态与主界面其他 checkbox 风格保持一致。

## 影响范围

  - `tasks/tools/infinite_battle.py`：3 个 checkbox
  - `tasks/tools/production_module.py`：1 个 checkbox
  - 仅替换控件类型并调整 import，不涉及其他逻辑改动。