### PR TITLE
fix(config): close paren in game_path default + single source of truth

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ permissions:
   actions: read
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,25 @@ jobs:
             --current-run-number "${{ github.run_number }}" \
             --fallback-version "${{ github.sha }}"
 
-  # 复用既有打包流程，只替换传入的构建版本号。
+  # 跑 pytest。这些测试只做静态解析（AST + ruamel），不 import 项目代码，
+  # 所以跟平台无关，放在 ubuntu 上跑最快最省。用 --no-project 跳过整套项目依赖
+  # （否则 uv 会去装 pywin32 这类 Windows-only 包，在 Linux 上必然失败），
+  # 只临时拉测试真正需要的 pytest + ruamel.yaml。
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Setup UV for Python
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Run pytest
+        run: uv run --no-project --python 3.12 --with pytest --with "ruamel.yaml" pytest -ra
+
+  # 复用既有打包流程，只替换传入的构建版本号。测试不过就不打包。
   build:
-    needs: prepare-version
+    needs: [prepare-version, test]
     uses: ./.github/workflows/reusable-build.yml
     with:
       version: ${{ needs.prepare-version.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,21 +45,24 @@ jobs:
             --current-run-number "${{ github.run_number }}" \
             --fallback-version "${{ github.sha }}"
 
-  # 跑 pytest。这些测试只做静态解析（AST + ruamel），不 import 项目代码，
-  # 所以跟平台无关，放在 ubuntu 上跑最快最省。用 --no-project 跳过整套项目依赖
-  # （否则 uv 会去装 pywin32 这类 Windows-only 包，在 Linux 上必然失败），
-  # 只临时拉测试真正需要的 pytest + ruamel.yaml。
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@main
 
       - name: Setup UV for Python
         uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/uv.lock
+
+      - name: Install dependencies
+        run: uv sync --frozen
 
       - name: Run pytest
-        run: uv run --no-project --python 3.12 --with pytest --with "ruamel.yaml" pytest -ra
+        run: uv run pytest -ra
 
   # 复用既有打包流程，只替换传入的构建版本号。测试不过就不打包。
   build:

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -139,6 +139,68 @@ teams_order: [0] # 队伍的顺序
 mirror_keyboard_navigation: False # 使用键盘进行镜牢寻路
 
 # 队伍设置
-teams_active_queue: []
+teams_active_queue: [] # 镜牢启用队伍的执行队列（单一事实源）
 teams:
-  '1': {} # 默认一个空队伍；具体默认值由 TeamSetting 提供（每个编队配置不同，不在此枚举）
+  '1':
+    team_system: 0 # 队伍使用的体系
+    team_number: 1 # 使用的队伍序号
+    shop_strategy: 0 # 商店策略
+    sinners_be_select: 0 # 有几名罪人被选中
+    chosen_sinners: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # 有哪几名罪人被选中
+    sinner_order: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # 罪人被选中的顺序
+    system_burn: False # 弃置燃烧饰品
+    system_bleed: False # 弃置流血饰品
+    system_tremor: False # 弃置震颤饰品
+    system_rupture: False # 弃置破裂饰品
+    system_poise: False # 弃置呼吸饰品
+    system_sinking: False # 弃置沉沦饰品
+    system_charge: False # 弃置充能饰品
+    system_slash: False # 弃置斩击饰品
+    system_pierce: False # 弃置穿刺饰品
+    system_blunt: False # 弃置打击饰品
+    do_not_heal: False # 不治疗
+    do_not_buy: False # 不购买
+    do_not_fuse: False # 不合成
+    do_not_sell: False # 不出售
+    do_not_enhance: False # 不升级
+    only_aggressive_fuse: False # 合成只采取激进策略
+    do_not_system_fuse: False # 不合成体系饰品
+    only_system_fuse: False # 只合成体系饰品
+    avoid_skill_3: False # 避免使用3技能
+    re_formation_each_floor: False # 每个楼层重新编队
+    use_starlight: False # 开局星光换钱
+    aggressive_also_enhance: False # 激进合成期间也升级饰品
+    aggressive_save_systems: False # 激进合成保留体系饰品
+    defense_first_round: False # 第一回合全员防御
+    fixed_team_use: False # 固定队伍用途
+    fixed_team_use_select: 0 # 固定队伍用途的选择项
+    reward_cards: False # 奖励卡优先度
+    reward_cards_select: 0 # 自定义奖励卡优先度
+    opening_bonus: [1, 1, 1, 1, 0, 0, 0, 0, 0, 0] # 开局星光加成：0 未选中，1 基础，2 +，3 ++
+    after_level_IV: False # 自定义合成四级后的操作
+    after_level_IV_select: 0 # 合成四级后的操作
+    shopping_strategy: False # 自定义购物策略
+    shopping_strategy_select: 0 # 购物策略
+    opening_items: False # 自定义开局道具
+    opening_items_select: 0 # 开局道具选择顺序
+    opening_items_system: 0 # 开局道具体系
+    second_system: False # 启用第二体系
+    second_system_select: 0 # 第二体系
+    second_system_setting: 0 # 第二体系启用时间
+    second_system_action: [0, 0, 0, 0] # 第二体系行动模式
+    skill_replacement: False # 自定义技能替换
+    skill_replacement_select: 0 # 技能替换设置
+    skill_replacement_mode: 0 # 技能替换模式
+    observe_ego_gift: False # 观测饰品
+    observe_ego_gift_selected: [] # 已选观测饰品
+    ignore_shop: [0, 0, 0, 0, 0] # 忽略商店楼层
+    max_keyword_refresh: 1 # 每次商店访问时定向刷新商品的次数上限
+    max_normal_refresh: 1 # 每次商店访问时普通刷新商品的次数上限
+    use_custom_theme_pack_weight: False # 使用队伍自定义主题包权重
+    remark_name: # 队伍备注名
+    use_team_code: False # 使用编队码
+    team_code: "" # 编队码
+    total_mirror_time_hard: [] # 困难镜牢总用时
+    mirror_hard_count: 0 # 困难镜牢次数
+    total_mirror_time_normal: [] # 普通镜牢总用时
+    mirror_normal_count: 0 # 普通镜牢次数

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -139,6 +139,7 @@ teams_order: [0] # 队伍的顺序
 mirror_keyboard_navigation: False # 使用键盘进行镜牢寻路
 
 # 队伍设置
+teams_active_queue: [] # 镜牢启用队伍的执行队列（单一事实源）
 teams:
   '1':
     team_system: 0 # 队伍使用的体系

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -139,66 +139,6 @@ teams_order: [0] # 队伍的顺序
 mirror_keyboard_navigation: False # 使用键盘进行镜牢寻路
 
 # 队伍设置
-teams_active_queue: [] # 镜牢启用队伍的执行队列（单一事实源）
+teams_active_queue: []
 teams:
-  '1':
-    team_system: 0 # 队伍使用的体系
-    team_number: 1 # 使用的队伍序号
-    shop_strategy: 0 # 商店策略
-    sinners_be_select: 0 # 有几名罪人被选中
-    chosen_sinners: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # 有哪几名罪人被选中
-    sinner_order: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] # 罪人被选中的顺序
-    system_burn: False # 弃置燃烧饰品
-    system_bleed: False # 弃置流血饰品
-    system_tremor: False # 弃置震颤饰品
-    system_rupture: False # 弃置破裂饰品
-    system_poise: False # 弃置呼吸饰品
-    system_sinking: False # 弃置沉沦饰品
-    system_charge: False # 弃置充能饰品
-    system_slash: False # 弃置斩击饰品
-    system_pierce: False # 弃置穿刺饰品
-    system_blunt: False # 弃置打击饰品
-    do_not_heal: False # 不治疗
-    do_not_buy: False # 不购买
-    do_not_fuse: False # 不合成
-    do_not_sell: False # 不出售
-    do_not_enhance: False # 不升级
-    only_aggressive_fuse: False # 合成只采取激进策略
-    do_not_system_fuse: False # 不合成体系饰品
-    only_system_fuse: False # 只合成体系饰品
-    avoid_skill_3: False # 避免使用3技能
-    re_formation_each_floor: False # 每个楼层重新编队
-    use_starlight: False # 开局星光换钱
-    aggressive_also_enhance: False # 激进合成期间也升级饰品
-    aggressive_save_systems: False # 激进合成保留体系饰品
-    defense_first_round: False # 第一回合全员防御
-    fixed_team_use: False # 固定队伍用途
-    fixed_team_use_select: 0 # 固定队伍用途的选择项
-    reward_cards: False # 奖励卡优先度
-    reward_cards_select: 0 # 自定义奖励卡优先度
-    opening_bonus: [1, 1, 1, 1, 0, 0, 0, 0, 0, 0] # 开局星光加成：0 未选中，1 基础，2 +，3 ++
-    after_level_IV: False # 自定义合成四级后的操作
-    after_level_IV_select: 0 # 合成四级后的操作
-    shopping_strategy: False # 自定义购物策略
-    shopping_strategy_select: 0 # 购物策略
-    opening_items: False # 自定义开局道具
-    opening_items_select: 0 # 开局道具选择顺序
-    opening_items_system: 0 # 开局道具体系
-    second_system: False # 启用第二体系
-    second_system_select: 0 # 第二体系
-    second_system_setting: 0 # 第二体系启用时间
-    second_system_action: [0, 0, 0, 0] # 第二体系行动模式
-    skill_replacement: False # 自定义技能替换
-    skill_replacement_select: 0 # 技能替换设置
-    skill_replacement_mode: 0 # 技能替换模式
-    ignore_shop: [0, 0, 0, 0, 0] # 忽略商店楼层
-    max_keyword_refresh: 1 # 每次商店访问时定向刷新商品的次数上限
-    max_normal_refresh: 1 # 每次商店访问时普通刷新商品的次数上限
-    use_custom_theme_pack_weight: False # 使用队伍自定义主题包权重
-    remark_name: # 队伍备注名
-    use_team_code: False # 使用编队码
-    team_code: "" # 编队码
-    total_mirror_time_hard: [] # 困难镜牢总用时
-    mirror_hard_count: 0 # 困难镜牢次数
-    total_mirror_time_normal: [] # 普通镜牢总用时
-    mirror_normal_count: 0 # 普通镜牢次数
+  '1': {} # 默认一个空队伍；具体默认值由 TeamSetting 提供（每个编队配置不同，不在此枚举）

--- a/module/config/config.py
+++ b/module/config/config.py
@@ -37,14 +37,15 @@ class Config(metaclass=SingletonMeta):
 
         # 加载版本信息
         self.version = self._load_version(version_path)
-        # 加载默认配置
-        self.config = ConfigModel()
-        # 获取用户的配置文件路径
+        # 用户配置文件路径
         self.config_path = Path(config_path)
-        # 保存含有注释的yaml文件的路径
+        # example.yaml：既是带注释的模板，也是默认值的唯一来源
         self.example_path = Path(example_path)
-
         self.backup_path = Path(backup_path)
+
+        # 默认值全部来自 example.yaml（单一来源）；ConfigModel 只负责类型与校验，不再硬编码默认值
+        self._defaults: dict = self._load_default_config()
+        self.config = ConfigModel(**self._defaults)
 
         # 加载实际配置，此方法会根据实际配置覆盖默认配置
         self._load_config()
@@ -226,9 +227,9 @@ class Config(metaclass=SingletonMeta):
                             log.error(
                                 f"最新的备份文件 {backup_files[0].name} 无法读取到有效配置，请自行通过 {self.backup_path.name} 文件夹下其他文件恢复数据"
                             )
-                            loaded_config = ConfigModel().model_dump()
+                            loaded_config = ConfigModel(**self._defaults).model_dump()
                     else:
-                        loaded_config = ConfigModel().model_dump()
+                        loaded_config = ConfigModel(**self._defaults).model_dump()
                 if not isinstance(loaded_config.get("config_version", 0), int):
                     raise TypeError("配置文件版本号不是 int 类型")
                 if loaded_config.get("config_version", 0) < self.config.config_version:
@@ -236,7 +237,7 @@ class Config(metaclass=SingletonMeta):
                     loaded_config["config_version"] = self.config.config_version
                     self._old_version_cfg_upgrade(saved_version, loaded_config)
                 # 使用更新后的配置初始化 Config 对象
-                self.config = ConfigModel(**loaded_config)
+                self.config = ConfigModel(**{**self._defaults, **loaded_config})
                 queue_in_loaded_config = loaded_config.get("teams_active_queue")
                 if queue_in_loaded_config is None:
                     normalized_queue = self._normalize_team_queue(self.migrate_legacy_team_queue())
@@ -531,7 +532,7 @@ class Config(metaclass=SingletonMeta):
             with open(path, "r", encoding="utf-8") as file:
                 loaded_config = self.yaml.load(file)
             if loaded_config:
-                self.config = ConfigModel(**loaded_config)
+                self.config = ConfigModel(**{**self._defaults, **loaded_config})
                 queue_in_loaded_config = loaded_config.get("teams_active_queue")
                 if queue_in_loaded_config is None:
                     normalized_queue = self._normalize_team_queue(self.migrate_legacy_team_queue())

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -196,328 +196,328 @@ class TeamSetting(BaseModel):
 class ConfigModel(BaseModel):
     """配置模型"""
 
-    config_version: int = 1781049600
+    config_version: int
     """配置文件版本号（时间戳）"""
 
-    game_title_name: str = "LimbusCompany"
+    game_title_name: str
     """游戏窗口标题"""
 
-    game_process_name: str = "LimbusCompany.exe"
+    game_process_name: str
     """游戏进程名"""
 
-    game_path: str = r"C:\Program Files (x86)\Steam\steamapps\common\Limbus Company\LimbusCompany.exe"
+    game_path: str
     """游戏启动路径"""
 
-    after_completion_actions: List[str] = []
+    after_completion_actions: List[str]
     """脚本结束后的前置动作（可多选）：exit_game/exit_emulator/exit_aalc"""
 
-    after_completion_power_action: str = "none"
+    after_completion_power_action: str
     """脚本结束后的最终动作（单选）：none/sleep/hibernate/lock/shutdown"""
 
-    keep_after_completion: bool = False
+    keep_after_completion: bool
     """是否保持脚本结束后的操作"""
 
-    language_in_program: str = ""
+    language_in_program: str
     """程序语言"""
 
-    shutdown_hotkey: str = "<ctrl>+q"
+    shutdown_hotkey: str
     """关闭快捷键"""
 
-    pause_hotkey: str = "<alt>+p"
+    pause_hotkey: str
     """暂停快捷键"""
 
-    resume_hotkey: str = "<alt>+r"
+    resume_hotkey: str
     """继续快捷键"""
 
-    announcement: float = 1715990400
+    announcement: float
     """公告板时间戳"""
 
-    memory_protection: bool = False
+    memory_protection: bool
     """内存占用保护"""
 
-    background_click: bool = True
+    background_click: bool
     """是否使用后台点击"""
 
-    win_input_type: str = "background"
+    win_input_type: str
     """键鼠操控方式"""
 
-    auto_hard_mirror: bool = False
+    auto_hard_mirror: bool
     """周四自动切换困难镜牢"""
 
-    last_auto_change: float = 1715990400
+    last_auto_change: float
     """上次自动切换困难镜牢的时间戳"""
 
-    hard_mirror_chance: int = 0
+    hard_mirror_chance: int
     """困难镜牢剩余次数"""
 
-    zoom_scale: int = 0
+    zoom_scale: int
     """缩放比例"""
 
-    window_position_x: int = 0
+    window_position_x: int
     """窗口位置x"""
 
-    window_position_y: int = 0
+    window_position_y: int
     """窗口位置y"""
 
-    theme_mode: str = "AUTO"
+    theme_mode: str
     """应用主题：AUTO, LIGHT, DARK"""
 
-    autostart: bool = False
+    autostart: bool
     """自启动"""
 
-    autodaily: bool = False
+    autodaily: bool
     """启用定时执行"""
 
-    autodaily_task: List[bool] = [False] * 4
+    autodaily_task: List[bool]
     """定时任务列表"""
 
-    autodaily_task_exit: List[bool] = [False] * 7
+    autodaily_task_exit: List[bool]
     """定时任务退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
-    autodaily_time: str = "00:00"
+    autodaily_time: str
     """定时执行时间（HH:mm）"""
 
-    autodaily2: bool = False
+    autodaily2: bool
     """启用定时执行2"""
 
-    autodaily2_task: List[bool] = [False] * 4
+    autodaily2_task: List[bool]
     """定时任务2列表"""
 
-    autodaily2_task_exit: List[bool] = [False] * 7
+    autodaily2_task_exit: List[bool]
     """定时任务2退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
-    autodaily_time2: str = "00:00"
+    autodaily_time2: str
     """定时执行时间2（HH:mm）"""
 
-    autodaily3: bool = False
+    autodaily3: bool
     """启用定时执行3"""
 
-    autodaily3_task: List[bool] = [False] * 4
+    autodaily3_task: List[bool]
     """定时任务3列表"""
 
-    autodaily3_task_exit: List[bool] = [False] * 7
+    autodaily3_task_exit: List[bool]
     """定时任务3退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
-    autodaily_time3: str = "00:00"
+    autodaily_time3: str
     """定时执行时间3（HH:mm）"""
 
-    autodaily4: bool = False
+    autodaily4: bool
     """启用定时执行4"""
 
-    autodaily4_task: List[bool] = [False] * 4
+    autodaily4_task: List[bool]
     """定时任务4列表"""
 
-    autodaily4_task_exit: List[bool] = [False] * 7
+    autodaily4_task_exit: List[bool]
     """定时任务4退出列表: [exit_game, exit_aalc, sleep, hibernate, shutdown, lock, exit_emulator]"""
 
-    autodaily_time4: str = "00:00"
+    autodaily_time4: str
     """定时执行时间4（HH:mm）"""
 
-    minimize_to_tray: bool = False
+    minimize_to_tray: bool
     """最小化到托盘"""
 
-    screenshot_interval: float = 0.85
+    screenshot_interval: float
     """截图间隔时间"""
 
-    mouse_action_interval: float = 0.5
+    mouse_action_interval: float
     """鼠标操作间隔时间"""
 
-    mouse_down_duration: float = 0.1
+    mouse_down_duration: float
     """鼠标按下持续时间"""
 
-    use_post_message: bool = False
+    use_post_message: bool
     """是否使用PostMessage进行输入"""
 
-    resonate_with_Ahab: bool = False
+    resonate_with_Ahab: bool
     """是否播放亚哈语录"""
 
-    experimental_keep_screen_awake: bool = False
+    experimental_keep_screen_awake: bool
     """运行期间阻止系统与显示器休眠，任务结束自动恢复"""
 
-    simulator: bool = False
+    simulator: bool
     """是否使用模拟器"""
 
-    simulator_type: int = 0
+    simulator_type: int
     """0:mumu, 10:其他"""
 
-    simulator_port: int = 0
+    simulator_port: int
     """端口"""
 
-    mumu_instance_number: int = -1
+    mumu_instance_number: int
     """mumu模拟器的实例编号"""
 
-    start_emulator_timeout: int = 120
+    start_emulator_timeout: int
     """启动模拟器超时时间"""
 
-    adb_reconnect_on_error: bool = True
+    adb_reconnect_on_error: bool
     """ADB或minitouch连接失效时自动重连"""
 
-    check_update: bool = True
+    check_update: bool
     """检查更新"""
 
-    update_prerelease_enable: bool = False
+    update_prerelease_enable: bool
     """启用预发布版更新"""
 
-    update_source: str = "GitHub"
+    update_source: str
     """更新源"""
 
-    mirrorchyan_cdk: str = ""
+    mirrorchyan_cdk: str
     """Mirror酱 CDK"""
 
-    image_resource_sync: bool = True
+    image_resource_sync: bool
     """是否启用图片资源自动同步"""
 
-    image_resource_source: str = "Auto"
+    image_resource_source: str
     """图片资源同步源"""
 
-    default_page: int = 0
+    default_page: int
     """保存启动后的页面"""
 
-    set_windows: bool = True
+    set_windows: bool
     """是否进行自动窗口设置"""
 
-    set_win_size: int = 1080
+    set_win_size: int
     """设置使用的分辨率"""
 
-    set_win_position: str = "free"
+    set_win_position: str
     """是否自动设置窗口的位置"""
 
-    set_reduce_miscontact: bool = True
+    set_reduce_miscontact: bool
     """是否防止误触"""
 
-    select_team_by_order: bool = False
+    select_team_by_order: bool
     """是否按顺序（而非名称）选择队伍"""
 
-    daily_task: bool = False
+    daily_task: bool
     """是否进行日常本"""
 
-    set_EXP_count: int = 1
+    set_EXP_count: int
     """设置经验本的次数"""
 
-    set_thread_count: int = 3
+    set_thread_count: int
     """设置纽本的次数"""
 
-    daily_teams: int = 1
+    daily_teams: int
     """设置日常本使用的队伍"""
 
-    targeted_teaming_EXP: bool = False
+    targeted_teaming_EXP: bool
     """经验本指定队伍"""
 
-    EXP_day_1_2: int = 1
+    EXP_day_1_2: int
     """周一/二经验本队伍"""
 
-    EXP_day_3_4: int = 1
+    EXP_day_3_4: int
     """周三/四经验本队伍"""
 
-    EXP_day_5_6: int = 1
+    EXP_day_5_6: int
     """周五/六经验本队伍"""
 
-    EXP_day_7: int = 1
+    EXP_day_7: int
     """周日经验本队伍"""
 
-    targeted_teaming_thread: bool = False
+    targeted_teaming_thread: bool
     """纽本指定队伍"""
 
-    use_continuous_combat: bool = False
+    use_continuous_combat: bool
     """是否使用连续作战"""
 
-    use_continuous_combat_select: int = 1
+    use_continuous_combat_select: int
     """一场连续作战的最大次数"""
 
-    thread_day_1: int = 1
+    thread_day_1: int
     """周一纽本队伍"""
 
-    thread_day_2: int = 1
+    thread_day_2: int
     """周二纽本队伍"""
 
-    thread_day_3: int = 1
+    thread_day_3: int
     """周三纽本队伍"""
 
-    thread_day_4: int = 1
+    thread_day_4: int
     """周四纽本队伍"""
 
-    thread_day_5: int = 1
+    thread_day_5: int
     """周五纽本队伍"""
 
-    thread_day_6: int = 1
+    thread_day_6: int
     """周六纽本队伍"""
 
-    thread_day_7: int = 1
+    thread_day_7: int
     """周日纽本队伍"""
 
-    get_reward: bool = False
+    get_reward: bool
     """是否进行获取奖励"""
 
-    set_get_prize: int = 0
+    set_get_prize: int
     """奖励领取模式"""
 
-    buy_enkephalin: bool = False
+    buy_enkephalin: bool
     """是否自动购买体力"""
 
-    set_lunacy_to_enkephalin: int = 2
+    set_lunacy_to_enkephalin: int
     """购买体力次数"""
 
-    Dr_Grandet_mode: bool = False
+    Dr_Grandet_mode: bool
     """葛朗台模式"""
 
-    skip_enkephalin: bool = False
+    skip_enkephalin: bool
     """跳过换体"""
 
-    mirror: bool = False
+    mirror: bool
     """是否进行自动镜牢"""
 
-    set_mirror_count: int = 1
+    set_mirror_count: int
     """镜牢的次数"""
 
-    hard_mirror: int | bool = 0
+    hard_mirror: int | bool
     """进行困难镜牢"""
 
-    no_weekly_bonuses: int | bool = 0
+    no_weekly_bonuses: int | bool
     """不使用每周加成"""
 
-    floor_3_exit: bool = False
+    floor_3_exit: bool
     """只打三层"""
 
-    infinite_dungeons: bool = False
+    infinite_dungeons: bool
     """无限刷牢"""
 
-    save_rewards: bool = False
+    save_rewards: bool
     """保存奖励不领"""
 
-    hard_mirror_single_bonuses: bool = False
+    hard_mirror_single_bonuses: bool
     """困难镜牢使用单次加成"""
 
-    select_event_pack: bool = False
+    select_event_pack: bool
     """第五层选择活动卡包"""
 
-    skip_event_pack: bool = False
+    skip_event_pack: bool
     """第五层跳过活动卡包"""
 
-    re_claim_rewards: bool = False
+    re_claim_rewards: bool
     """再次执行领取奖励任务"""
 
-    not_skip_whitegossypium: bool = False
+    not_skip_whitegossypium: bool
     """不跳过白棉花"""
 
-    fight_to_last_man: bool = False
+    fight_to_last_man: bool
     """战斗直到全灭"""
 
-    teams_be_select_num: int = 0
+    teams_be_select_num: int
     """被选中的队伍数量"""
 
-    teams_be_select: List[bool] = [False]
+    teams_be_select: List[bool]
     """被选中的队伍"""
 
-    teams_order: List[int] = [0]
+    teams_order: List[int]
     """队伍的顺序"""
 
-    teams_active_queue: List[int] = []
+    teams_active_queue: List[int]
     """镜牢启用队伍的执行队列（单一事实源）"""
 
-    mirror_keyboard_navigation: bool = False
+    mirror_keyboard_navigation: bool
     """使用键盘进行镜牢寻路"""
 
-    teams: dict[str, TeamSetting] = {"1": TeamSetting()}
+    teams: dict[str, TeamSetting]
     """队伍设置"""
 
     @field_validator("use_continuous_combat_select")

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -205,7 +205,7 @@ class ConfigModel(BaseModel):
     game_process_name: str = "LimbusCompany.exe"
     """游戏进程名"""
 
-    game_path: str = r"C:\Program Files (x86\Steam\steamapps\common\Limbus Company\LimbusCompany.exe"
+    game_path: str = r"C:\Program Files (x86)\Steam\steamapps\common\Limbus Company\LimbusCompany.exe"
     """游戏启动路径"""
 
     after_completion_actions: List[str] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pyinstaller>=6.16.0",
+    "pytest>=9.1.0",
     "ruff>=0.13.1",
     "watchdog",
 ]
@@ -88,3 +89,8 @@ ignore = ["E501"]
 [tool.ruff]
 line-length = 120
 target-version = "py312"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+addopts = "-ra"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -65,10 +65,3 @@ def test_config_model_has_no_hardcoded_defaults() -> None:
     assert (
         with_default == []
     ), f"下列 ConfigModel field 带有 default：{with_default}"
-
-
-def test_game_path_default_paren_intact() -> None:
-    # Regression：game_path 默认路径里的 (x86) 括号完整
-    # （曾经少了 right parenthesis 导致默认游戏路径无效）
-    game_path: str = YAML().load(EXAMPLE_PATH.read_text(encoding="utf-8"))["game_path"]
-    assert "(x86)" in game_path, f"game_path 括号不完整：{game_path!r}"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -1,0 +1,72 @@
+"""
+config schema single source of truth test
+
+config 默认值的唯一来源是 assets/config/config.example.yaml
+ConfigModel (module/config/config_typing.py) 只声明类型、不带 default
+用 AST + ruamel 静态比对 ConfigModel 里声明的字段和 example.yaml 里定义的字段完全一致（不多也不少）
+如果不一致了，说明改 config 相关代码时忘了同步修改某个地方，测试会报错提醒开发者检查并修正
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List, Set
+
+from ruamel.yaml import YAML
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[1]
+EXAMPLE_PATH: Path = REPO_ROOT / "assets" / "config" / "config.example.yaml"
+TYPING_PATH: Path = REPO_ROOT / "module" / "config" / "config_typing.py"
+
+
+def _example_keys() -> Set[str]:
+    """从 example.yaml 里加载 config 字段名集合"""
+    return set(YAML().load(EXAMPLE_PATH.read_text(encoding="utf-8")))
+
+
+def _config_model_fields() -> List[ast.AnnAssign]:
+    """
+    从 ConfigModel 的 AST 里提取出所有字段声明（AnnAssign）
+    """
+    tree: ast.Module = ast.parse(TYPING_PATH.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "ConfigModel":
+            return [s for s in node.body if isinstance(s, ast.AnnAssign)]
+    raise AssertionError("config_typing.py 里找不到 ConfigModel")
+
+
+def _field_name(stmt: ast.AnnAssign) -> str:
+    """
+    从 ConfigModel AST 解析出的赋值语句里获取字段名
+    """
+    assert isinstance(stmt.target, ast.Name)
+    return stmt.target.id
+
+
+def test_model_fields_match_example_keys() -> None:
+    model_keys: Set[str] = {_field_name(s) for s in _config_model_fields()}
+    example_keys: Set[str] = _example_keys()
+    assert model_keys == example_keys, (
+        "ConfigModel 和 example.yaml 的 key 不一致：\n"
+        f"  只在 model:   {sorted(model_keys - example_keys)}\n"
+        f"  只在 example: {sorted(example_keys - model_keys)}"
+    )
+
+
+def test_config_model_has_no_hardcoded_defaults() -> None:
+    # ConfigModel 是纯 typing：默认值只准放 example.yaml，不在 model 里硬编码
+    # 保证 single source of truth，避免改 config 相关代码时忘了同步修改某个地方
+    with_default: List[str] = [
+        _field_name(s) for s in _config_model_fields() if s.value is not None
+    ]
+    assert (
+        with_default == []
+    ), f"下列 ConfigModel field 带有 default：{with_default}"
+
+
+def test_game_path_default_paren_intact() -> None:
+    # Regression：game_path 默认路径里的 (x86) 括号完整
+    # （曾经少了 right parenthesis 导致默认游戏路径无效）
+    game_path: str = YAML().load(EXAMPLE_PATH.read_text(encoding="utf-8"))["game_path"]
+    assert "(x86)" in game_path, f"game_path 括号不完整：{game_path!r}"

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -22,7 +22,9 @@ TYPING_PATH: Path = REPO_ROOT / "module" / "config" / "config_typing.py"
 
 def _example_keys() -> Set[str]:
     """从 example.yaml 里加载 config 字段名集合"""
-    return set(YAML().load(EXAMPLE_PATH.read_text(encoding="utf-8")))
+    data = YAML().load(EXAMPLE_PATH.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"example.yaml 顶层应为 mapping，实际为 {type(data).__name__}"
+    return set(data.keys())
 
 
 def _config_model_fields() -> List[ast.AnnAssign]:

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pyinstaller" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "watchdog" },
 ]
@@ -101,6 +102,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pyinstaller", specifier = ">=6.16.0" },
+    { name = "pytest", specifier = ">=9.1.0" },
     { name = "ruff", specifier = ">=0.13.1" },
     { name = "watchdog" },
 ]
@@ -289,6 +291,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -584,6 +595,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -764,6 +784,15 @@ dependencies = [
     { name = "pyrect" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/70/c7a4f46dbf06048c6d57d9489b8e0f9c4c3d36b7479f03c5ca97eaa2541d/PyGetWindow-0.0.9.tar.gz", hash = "sha256:17894355e7d2b305cd832d717708384017c1698a90ce24f6f7fbf0242dd0a688", size = 9699, upload-time = "2020-10-04T02:12:50.806Z" }
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
 
 [[package]]
 name = "pyinstaller"
@@ -3584,6 +3613,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/f2/dde32565af5ae10841f4288a22f71debb6bf529b6b8149f629042f31e557/pysidesix_frameless_window-0.7.4.tar.gz", hash = "sha256:1b14ee5bf5438d6f5823e9a108a9d3c04c096f7db733b75f7e91e009684b0be0", size = 22771, upload-time = "2025-10-10T13:17:32.024Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/1e/5bfb71bb258d7fe5b6a89197ae1d8b318ea6895ba5e5b2cdabed0956b07d/pysidesix_frameless_window-0.7.4-py3-none-any.whl", hash = "sha256:26eca5f28e1e08ff8e619de6b8a8c19aa85fe3c07efc2bf05693015430c7ea68", size = 30595, upload-time = "2025-10-10T13:17:30.885Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR 内容

commit 33a2124 修复了目前 AALC 启动时由于 `module/config/config_typing.py` 中遗漏括号造成的启动时 ERROR message
```
[ERROR] 2026-06-18 21:35:11,530 [AALC] module\game_and_screen\game.py:52: 游戏路径不存在：C:\Program Files (x86\Steam\steamapps\common\Limbus Company\LimbusCompany.exe，使用steam命令启动...
```
注意到 `config.example.yaml` 里实际上是有正确的默认游戏路径的。但 main 上 `_save_config()` 是先读 example 当注释/结构模板，再用 `self.config.model_dump()` 全量覆盖，而 `self.config` 在初始化时取得就是 `ConfigModel` 的 hardcoded default，这里面出了个（一直没被发现的） typo，于是启动时默认路径就一直找不到了。对于新安装用户来说 example 里的值其实不生效。

这意味着 `ConfigModel` 里的 hardcoded default 和 `config.example.yaml` 里的值是两份需要同步维护的内容，加新 field 时如果只改了一处就会产生漂移。而这种漂移已经发生：`teams_active_queue` 存在于 `ConfigModel` 中，但在 `config.example.yaml` 里根本找不到这个 key。

故而本 PR 的剩余 commit 都是为了解决需要同步维护两份 default 的问题： 移除 `ConfigModel` 的所有 hardcoded default，以 `config.example.yaml` 作为 single source of truth，config loader 改为在初始化时从 `config.example.yaml` 读取 defaults 并传入。同时新增 tests/test_config_schema.py，用 AST + ruamel 静态比对 ConfigModel 和 example 的 key 和 default 值状态，防止日后再次漂移。并且将该 test 接入 CI，卡在 build 之前。

## Merge 建议

如果 maintainer 同意 config 相关的优化可以直接合并整个 PR。若有其他考量可以 cherry-pick 第一个 commit。

## 其他有关配置的建议

`TeamSetting` 的 hardcoded default 不受影响。不过个人体感这个 setting 应该直接拆出来，不应和其它 config 一同管理。其它 field 描述的都是"这台机器上 AALC 怎么跑"，而 `TeamSetting` 描述的是"用哪套编队、用什么策略"，后者 environment agnostic、天然可分享。目前 export/import 功能实际上已经在把 team config 当独立文件对待了，只是多绕了一圈"先写进 `config.yaml` 再从里面导出"。

更合适的做法是让 team config 直接以独立文件存在（比如 `teams/` 目录，每个队一个 YAML），`config.yaml` 里只保留 `teams_active_queue` 引用执行顺序。这样 config.yaml 就真正只剩 app 级别的设置，team 文件可以直接分享（甚至都没必要写 export 了），不再和用户配置混存。

这个 refactor 对于本 PR out of scope 了，但是觉得 worth mentioning...