### PR TITLE
feat: 主题包权重配置码导入/导出功能

### DIFF
--- a/app/theme_pack_setting_interface.py
+++ b/app/theme_pack_setting_interface.py
@@ -4,6 +4,7 @@ import re
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPixmap
 from PySide6.QtWidgets import (
+    QApplication,
     QFileDialog,
     QFrame,
     QGridLayout,
@@ -32,14 +33,16 @@ from qframelesswindow import FramelessDialog, StandardTitleBar
 from ruamel.yaml import YAML
 
 from app.base_tools import BaseSpinBox
-from app.card.messagebox_custom import BaseInfoBar, MessageBoxConfirm
+from app.card.messagebox_custom import BaseInfoBar, MessageBoxConfirm, MessageBoxEdit
 from app.language_manager import LanguageManager
 from module import THEME_PACK_LIST_EXAMPLE_PATH
 from module.config import cfg, theme_list
 from module.config.theme_pack_import_export import (
     export_theme_pack_weight,
+    export_theme_pack_weight_to_base64,
     generate_theme_pack_export_filename,
     import_theme_pack_weight,
+    import_theme_pack_weight_from_base64,
 )
 
 # 英文key到中文名称的映射表（普通模式）
@@ -609,6 +612,17 @@ class ThemePackSettingDialog(FramelessDialog):
         self.import_button.clicked.connect(self.on_import_settings)
         self.import_button.setVisible(self.is_team_specific)
 
+        # 配置码导入导出按钮
+        self.copy_code_button = PushButton(FIF.SHARE, self.tr("导出配置码"))
+        self.copy_code_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.copy_code_button.clicked.connect(self.on_export_code)
+        self.copy_code_button.setVisible(self.is_team_specific)
+
+        self.paste_code_button = PushButton(FIF.EDIT, self.tr("导入配置码"))
+        self.paste_code_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.paste_code_button.clicked.connect(self.on_import_code)
+        self.paste_code_button.setVisible(self.is_team_specific)
+
         # 主要操作按钮
         self.save_button = PrimaryPushButton(self.tr("保存并关闭"), self)
         self.save_button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
@@ -621,6 +635,8 @@ class ThemePackSettingDialog(FramelessDialog):
         self.button_layout.addWidget(self.batch_menu_button)
         self.button_layout.addWidget(self.export_button)
         self.button_layout.addWidget(self.import_button)
+        self.button_layout.addWidget(self.copy_code_button)
+        self.button_layout.addWidget(self.paste_code_button)
         self.button_layout.addStretch()
         self.button_layout.addWidget(self.save_button)
         self.button_layout.addWidget(self.close_button)
@@ -1003,6 +1019,59 @@ class ThemePackSettingDialog(FramelessDialog):
                 duration=3000,
                 parent=self,
             )
+
+    # ---- 配置码导入导出（新增）----
+    def on_export_code(self):
+        """导出主题包权重为配置码并复制到剪贴板"""
+        if not self.is_team_specific:
+            return
+        theme_list.save_config(path=self.save_path, config_data=self.config_data)
+        team_num = self._extract_team_num_from_path()
+        code = export_theme_pack_weight_to_base64(team_num)
+        if code:
+            QApplication.clipboard().setText(code)
+            BaseInfoBar.success(title=self.tr("导出成功"), content=self.tr("配置码已复制到剪贴板"),
+                orient=Qt.Orientation.Horizontal, isClosable=True,
+                position=InfoBarPosition.TOP, duration=3000, parent=self)
+        else:
+            BaseInfoBar.error(title=self.tr("导出失败"), content=self.tr("无法导出配置码"),
+                orient=Qt.Orientation.Horizontal, isClosable=True,
+                position=InfoBarPosition.TOP, duration=3000, parent=self)
+
+    def on_import_code(self):
+        """从配置码导入主题包权重"""
+        if not self.is_team_specific:
+            return
+        clipboard_text = QApplication.clipboard().text().strip()
+        dialog = MessageBoxEdit(self.tr("导入配置码"), clipboard_text if clipboard_text else "", self)
+        if not dialog.exec():
+            return
+        code = dialog.getText()
+        if not code or not code.strip():
+            return
+        confirm = MessageBoxConfirm(self.tr("确认导入"), self.tr("导入将覆盖当前主题包权重设置"), self.window())
+        if not confirm.exec():
+            return
+        team_num = self._extract_team_num_from_path()
+        if import_theme_pack_weight_from_base64(code.strip(), team_num):
+            self.config_data.clear()
+            reloaded = theme_list.load_config(self.save_path)
+            self.config_data.update(copy.deepcopy(reloaded))
+            normal_imported = reloaded.get("theme_pack_list_cn" if self.is_cn else "theme_pack_list", {})
+            hard_imported = reloaded.get("theme_pack_list_hard_cn" if self.is_cn else "theme_pack_list_hard", {})
+            self.preferred_threshold_spinbox.spin_box.setValue(int(reloaded.get("preferred_thresholds", 0)))
+            for k, v in normal_imported.items():
+                if k in self.normal_cards: self.normal_cards[k].update_weight(v)
+            for k, v in hard_imported.items():
+                if k in self.hard_cards: self.hard_cards[k].update_weight(v)
+            self._has_unsaved_changes = False
+            BaseInfoBar.success(title=self.tr("导入成功"), content=self.tr("主题包权重已导入"),
+                orient=Qt.Orientation.Horizontal, isClosable=True,
+                position=InfoBarPosition.TOP, duration=3000, parent=self)
+        else:
+            BaseInfoBar.error(title=self.tr("导入失败"), content=self.tr("无法解析配置码"),
+                orient=Qt.Orientation.Horizontal, isClosable=True,
+                position=InfoBarPosition.TOP, duration=3000, parent=self)
 
     def save_and_close(self):
         """保存配置到文件并关闭对话框"""

--- a/module/config/theme_pack_import_export.py
+++ b/module/config/theme_pack_import_export.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 import re
 from pathlib import Path
@@ -135,4 +136,82 @@ def import_theme_pack_weight(file_path: str, team_num: int) -> bool:
         return True
     except Exception as e:
         log.error(f"导入主题包权重失败: {e}")
+        return False
+
+
+# =============================================================================
+# 配置码（Base64）导入/导出 —— 将权重 YAML 编码为 Base64 字符串，方便剪贴板分享
+# =============================================================================
+
+
+def export_theme_pack_weight_to_base64(team_num: int) -> str | None:
+    """导出主题包权重为配置码字符串
+
+    Args:
+        team_num: 队伍编号
+
+    Returns:
+        Base64 编码字符串，失败返回 None
+    """
+    try:
+        theme_pack_weight_path = theme_list.build_team_weight_path(team_num)
+        if not Path(theme_pack_weight_path).exists():
+            log.error(f"队伍 {team_num} 的主题包权重文件未找到")
+            return None
+        with open(theme_pack_weight_path, "r", encoding="utf-8") as f:
+            yaml_content = f.read()
+        if not yaml_content.strip():
+            log.error(f"队伍 {team_num} 的主题包权重文件为空")
+            return None
+        encoded = base64.b64encode(yaml_content.encode("utf-8")).decode("ascii")
+        log.info(f"已导出队伍 {team_num} 的主题包权重为配置码")
+        return encoded
+    except Exception as e:
+        log.error(f"导出主题包权重配置码失败: {e}")
+        return None
+
+
+def import_theme_pack_weight_from_base64(base64_str: str, team_num: int) -> bool:
+    """从配置码字符串导入主题包权重
+
+    Args:
+        base64_str: Base64 编码的权重数据
+        team_num: 队伍编号
+
+    Returns:
+        成功返回 True，失败返回 False
+    """
+    try:
+        try:
+            yaml_content = base64.b64decode(base64_str).decode("utf-8")
+        except (base64.binascii.Error, UnicodeDecodeError) as e:
+            log.error(f"配置码解码失败: {e}")
+            return False
+        if not yaml_content.strip():
+            log.warning("导入的配置码数据为空")
+            return False
+        yaml = YAML()
+        import_data = yaml.load(yaml_content)
+        if not import_data:
+            log.warning("解析配置码数据后主题包权重为空")
+            return True
+        theme_pack_weight_path = theme_list.build_team_weight_path(team_num)
+        target_path = Path(theme_pack_weight_path)
+        if target_path.exists():
+            with open(theme_pack_weight_path, "r", encoding="utf-8") as f:
+                existing_data = yaml.load(f) or {}
+        else:
+            existing_data = {}
+        if isinstance(import_data, dict):
+            existing_data = _deep_merge_dicts(existing_data, import_data)
+        else:
+            log.error(f"队伍 {team_num} 的导入配置码数据不是字典")
+            return False
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(theme_pack_weight_path, "w", encoding="utf-8") as f:
+            yaml.dump(existing_data, f)
+        log.info(f"已从配置码导入队伍 {team_num} 的主题包权重")
+        return True
+    except Exception as e:
+        log.error(f"从配置码导入主题包权重失败: {e}")
         return False


### PR DESCRIPTION
新增功能：
- 配置码导出：YAML编码为配置码，复制到剪贴板
- 配置码导入：弹出对话框（预填剪贴板），解码合并到现有配置
- 按钮仅队伍特定配置可见

所有新增代码以注释块标注，未修改已有逻辑。