### PR TITLE
feat: 新增启动后等待主界面超时自定义配置

### DIFF
--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -212,6 +212,15 @@ class SettingInterface(QWidget):
             content="",
             parent=self.simulator_setting_group,
         )
+        self.startup_wait_timeout_simulator_card = PushSettingCardChance(
+            QT_TRANSLATE_NOOP("PushSettingCardChance", "修改"),
+            FIF.DATE_TIME,
+            QT_TRANSLATE_NOOP("PushSettingCardChance", "模拟器启动后等待主界面超时时间(秒)"),
+            config_name="startup_wait_timeout_simulator",
+            max_value=3600,
+            content="",
+            parent=self.simulator_setting_group,
+        )
 
         self.game_path_group = BaseSettingCardGroup(
             QT_TRANSLATE_NOOP("BaseSettingCardGroup", "启动游戏"), self.scroll_widget
@@ -221,6 +230,15 @@ class SettingInterface(QWidget):
             FIF.FOLDER,
             QT_TRANSLATE_NOOP("BasePushSettingCard", "游戏路径"),
             cfg.game_path,
+            parent=self.game_path_group,
+        )
+        self.startup_wait_timeout_pc_card = PushSettingCardChance(
+            QT_TRANSLATE_NOOP("PushSettingCardChance", "修改"),
+            FIF.DATE_TIME,
+            QT_TRANSLATE_NOOP("PushSettingCardChance", "PC启动后等待主界面超时时间(秒)"),
+            config_name="startup_wait_timeout_pc",
+            max_value=3600,
+            content="",
             parent=self.game_path_group,
         )
         self.autostart_card = SwitchSettingCard(
@@ -473,8 +491,10 @@ class SettingInterface(QWidget):
         self.simulator_setting_group.addSettingCard(self.simulator_type_setting_card)
         self.simulator_setting_group.addSettingCard(self.simulator_port_chance_card)
         self.simulator_setting_group.addSettingCard(self.start_emulator_timeout_chance_card)
+        self.simulator_setting_group.addSettingCard(self.startup_wait_timeout_simulator_card)
 
         self.game_path_group.addSettingCard(self.game_path_card)
+        self.game_path_group.addSettingCard(self.startup_wait_timeout_pc_card)
         self.game_path_group.addSettingCard(self.autostart_card)
         self.game_path_group.addSettingCard(self.minimize_to_tray_card)
 
@@ -706,7 +726,9 @@ class SettingInterface(QWidget):
         self.simulator_type_setting_card.retranslateUi()
         self.simulator_port_chance_card.retranslateUi()
         self.start_emulator_timeout_chance_card.retranslateUi()
+        self.startup_wait_timeout_simulator_card.retranslateUi()
         self.game_path_card.retranslateUi()
+        self.startup_wait_timeout_pc_card.retranslateUi()
         self.game_path_group.retranslateUi()
         self.autodaily_group.retranslateUi()
         self.personal_group.retranslateUi()

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -5,6 +5,7 @@ game_title_name: LimbusCompany # 游戏窗口标题。
 game_process_name: LimbusCompany.exe # 游戏进程名。
 
 game_path: C:\Program Files (x86)\Steam\steamapps\common\Limbus Company\LimbusCompany.exe # 游戏启动路径。
+startup_wait_timeout_pc: 120 # PC启动游戏后等待主界面的超时时间(秒)
 
 keep_after_completion: False # 是否保持脚本结束后的操作
 language_in_program: "" # 程序语言
@@ -67,6 +68,7 @@ simulator_type: 0 # 0:mumu , 10:其他 。TODO:蓝迭 , 雷电 , 夜神 , 逍遥
 simulator_port: 0 # 端口
 mumu_instance_number: -1 # mumu模拟器的实例编号
 start_emulator_timeout: 120 # 启动模拟器超时时间
+startup_wait_timeout_simulator: 180 # 模拟器启动游戏后等待主界面的超时时间(秒)
 adb_reconnect_on_error: True # ADB或minitouch连接失效时自动重连
 
 # 自动更新

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -208,6 +208,9 @@ class ConfigModel(BaseModel):
     game_path: str
     """游戏启动路径"""
 
+    startup_wait_timeout_pc: int
+    """PC 启动游戏后等待主界面的超时时间（秒）"""
+
     after_completion_actions: List[str]
     """脚本结束后的前置动作（可多选）：exit_game/exit_emulator/exit_aalc"""
 
@@ -348,6 +351,9 @@ class ConfigModel(BaseModel):
 
     start_emulator_timeout: int
     """启动模拟器超时时间"""
+
+    startup_wait_timeout_simulator: int
+    """模拟器启动游戏后等待主界面的超时时间（秒）"""
 
     adb_reconnect_on_error: bool
     """ADB或minitouch连接失效时自动重连"""

--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -7,7 +7,12 @@ from module.config import cfg
 from module.decorator.decorator import begin_and_finish_time_log
 from module.logger import log
 from tasks.base import update_model_for_retry
-from tasks.base.retry import click_title_screen_safely, ensure_simulator_game_started, retry
+from tasks.base.retry import (
+    _is_runtime_ui_visible,
+    click_title_screen_safely,
+    ensure_simulator_game_started,
+    retry,
+)
 from tasks.mirror.reward_card import get_reward_card
 
 
@@ -64,7 +69,7 @@ def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries
                 continue
             if auto.click_element("home/window_assets.png") and auto.find_element("home/mail_assets.png", model="normal"):
                 return StartupMainMenuWaitResult.MAIN_MENU
-            if auto.find_element("home/back_assets.png") or auto.find_element("battle/setting_assets.png"):
+            if _is_runtime_ui_visible():
                 return StartupMainMenuWaitResult.RUNTIME_UI
             sleep(0.5)
         log.error(f"启动等待主界面超时（{timeout_seconds}秒）")

--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -12,6 +12,7 @@ from tasks.base.retry import (
     click_title_screen_safely,
     ensure_simulator_game_started,
     retry,
+    should_wait_for_main_menu_after_simulator_start,
 )
 from tasks.mirror.reward_card import get_reward_card
 
@@ -20,6 +21,18 @@ class StartupMainMenuWaitResult(StrEnum):
     MAIN_MENU = "main_menu"
     RUNTIME_UI = "runtime_ui"
     TIMEOUT = "timeout"
+
+
+def _is_retry_debug_enabled():
+    return bool(cfg.get_value("debug_mode", False) and cfg.get_value("debug_retry", False))
+
+
+def _screenshot_fingerprint():
+    screenshot = getattr(auto, "screenshot", None)
+    if screenshot is None:
+        return None
+    raw = screenshot.tobytes()
+    return hash(raw[: min(len(raw), 1024)])
 
 
 def get_startup_wait_timeout_seconds() -> int:
@@ -42,11 +55,15 @@ def handle_launch_state_once() -> bool | None:
         return True
     if auto.click_element("base/only_option_assets.png", model="clam"):
         return True
+    # 镜牢入口等游戏内子界面检测：按下ESC返回主菜单
+    if auto.find_element("mirror/road_to_mir/enter_assets.png"):
+        auto.key_press("esc")
+        sleep(0.5)
+        return True
     return None
 
 
-def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries: int = 3) -> StartupMainMenuWaitResult:
-    retries = 0
+def wait_until_main_menu_after_launch(*, allow_restart: bool = True) -> StartupMainMenuWaitResult:
     while True:
         auto.model = "clam"
         timeout_seconds = get_startup_wait_timeout_seconds()
@@ -54,6 +71,8 @@ def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries
         deadline = start_time + timeout_seconds
         halfway_logged = False
         halfway_threshold = start_time + timeout_seconds / 2
+        _last_fingerprint = None
+        _stale_count = 0
         while True:
             now = time.time()
             if now > deadline:
@@ -61,12 +80,36 @@ def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries
             if not halfway_logged and timeout_seconds >= 10 and now >= halfway_threshold:
                 log.info(f"启动后仍在等待进入主界面，已等待{int(now - start_time)}秒/{timeout_seconds}秒")
                 halfway_logged = True
+            auto.ensure_not_stopped()
             if ensure_simulator_game_started():
+                if not should_wait_for_main_menu_after_simulator_start():
+                    return StartupMainMenuWaitResult.RUNTIME_UI
                 continue
             if auto.take_screenshot() is None:
                 continue
+
+            fingerprint = _screenshot_fingerprint()
+            if fingerprint is None:
+                _stale_count = 0
+                _last_fingerprint = None
+            elif fingerprint == _last_fingerprint:
+                _stale_count += 1
+                if _stale_count >= 3:
+                    log.warning(f"检测到截屏冻结（连续 {_stale_count} 轮画面不变），跳过本轮")
+                    if _is_runtime_ui_visible():
+                        return StartupMainMenuWaitResult.RUNTIME_UI
+                    if hasattr(auto, "key_press"):
+                        log.debug("截屏冻结且无运行时 UI 匹配，尝试按 ESC 导航")
+                        auto.key_press("esc")
+                    sleep(0.5)
+                    continue
+            else:
+                _stale_count = 0
+                _last_fingerprint = fingerprint
+
             if handle_launch_state_once():
                 continue
+
             if auto.click_element("home/window_assets.png") and auto.find_element("home/mail_assets.png", model="normal"):
                 return StartupMainMenuWaitResult.MAIN_MENU
             if _is_runtime_ui_visible():
@@ -74,10 +117,6 @@ def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries
             sleep(0.5)
         log.error(f"启动等待主界面超时（{timeout_seconds}秒）")
         if not allow_restart:
-            return StartupMainMenuWaitResult.TIMEOUT
-        retries += 1
-        if retries > max_retries:
-            log.error(f"启动等待主界面已重试 {max_retries} 次仍超时，放弃重试")
             return StartupMainMenuWaitResult.TIMEOUT
         from tasks.base.retry import kill_game
         from tasks.base.script_task_scheme import init_game
@@ -88,10 +127,13 @@ def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries
 
 
 @begin_and_finish_time_log(task_name="返回主界面")
-def back_init_menu(*, allow_restart: bool = True):
+def back_init_menu(*, allow_restart: bool = True) -> bool:
     loop_count = 30
     auto.model = "clam"
+    _last_fingerprint = None
+    _stale_count = 0
     while True:
+        auto.ensure_not_stopped()
         loop_count -= 1
         update_model_for_retry(loop_count, normal_at=20, aggressive_at=10)
         if loop_count < 0:
@@ -107,10 +149,34 @@ def back_init_menu(*, allow_restart: bool = True):
             auto.model = "clam"
             sleep(1)
             continue
+        if _is_retry_debug_enabled():
+            log.info(f"[重试调试] 返回主界面 第{30 - loop_count}次循环, 模型={auto.model}")
+
         if ensure_simulator_game_started():
-            continue
+            if should_wait_for_main_menu_after_simulator_start():
+                wait_result = wait_until_main_menu_after_launch(allow_restart=allow_restart)
+                if wait_result == StartupMainMenuWaitResult.MAIN_MENU:
+                    return True
+                if wait_result == StartupMainMenuWaitResult.RUNTIME_UI:
+                    continue
+                return False
         if retry() is False:
             return False
+
+        # 截屏冻结检测：连续 3 轮相同画面则跳过（不点击），防止 Mumu 显存刷新延迟导致的无限误触
+        fingerprint = _screenshot_fingerprint()
+        if fingerprint is None:
+            _stale_count = 0
+            _last_fingerprint = None
+        elif fingerprint == _last_fingerprint:
+            _stale_count += 1
+            if _stale_count >= 3:
+                log.warning(f"检测到截屏冻结（连续 {_stale_count} 轮画面不变），跳过本轮")
+                sleep(0.5)
+                continue
+        else:
+            _stale_count = 0
+            _last_fingerprint = fingerprint
 
         if auto.click_element("home/window_assets.png") and auto.find_element("home/mail_assets.png", model="normal"):
             return True

--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -1,11 +1,85 @@
+import time
+from enum import StrEnum
 from time import sleep
 
 from module.automation import auto
+from module.config import cfg
 from module.decorator.decorator import begin_and_finish_time_log
 from module.logger import log
 from tasks.base import update_model_for_retry
 from tasks.base.retry import click_title_screen_safely, ensure_simulator_game_started, retry
 from tasks.mirror.reward_card import get_reward_card
+
+
+class StartupMainMenuWaitResult(StrEnum):
+    MAIN_MENU = "main_menu"
+    RUNTIME_UI = "runtime_ui"
+    TIMEOUT = "timeout"
+
+
+def get_startup_wait_timeout_seconds() -> int:
+    key = "startup_wait_timeout_simulator" if cfg.simulator else "startup_wait_timeout_pc"
+    default = 180 if cfg.simulator else 120
+    return int(cfg.get_value(key, default))
+
+
+def handle_launch_state_once() -> bool | None:
+    if auto.find_element("base/clear_all_caches_assets.png", model="clam"):
+        if auto.click_element("base/update_confirm_assets.png"):
+            return True
+        click_title_screen_safely()
+        return True
+    if auto.find_element("base/connecting_assets.png"):
+        return True
+    if auto.find_element("base/waiting_assets.png"):
+        return True
+    if auto.find_element("base/waiting_2_assets.png"):
+        return True
+    if auto.click_element("base/only_option_assets.png", model="clam"):
+        return True
+    return None
+
+
+def wait_until_main_menu_after_launch(*, allow_restart: bool = True, max_retries: int = 3) -> StartupMainMenuWaitResult:
+    retries = 0
+    while True:
+        auto.model = "clam"
+        timeout_seconds = get_startup_wait_timeout_seconds()
+        start_time = time.time()
+        deadline = start_time + timeout_seconds
+        halfway_logged = False
+        halfway_threshold = start_time + timeout_seconds / 2
+        while True:
+            now = time.time()
+            if now > deadline:
+                break
+            if not halfway_logged and timeout_seconds >= 10 and now >= halfway_threshold:
+                log.info(f"启动后仍在等待进入主界面，已等待{int(now - start_time)}秒/{timeout_seconds}秒")
+                halfway_logged = True
+            if ensure_simulator_game_started():
+                continue
+            if auto.take_screenshot() is None:
+                continue
+            if handle_launch_state_once():
+                continue
+            if auto.click_element("home/window_assets.png") and auto.find_element("home/mail_assets.png", model="normal"):
+                return StartupMainMenuWaitResult.MAIN_MENU
+            if auto.find_element("home/back_assets.png") or auto.find_element("battle/setting_assets.png"):
+                return StartupMainMenuWaitResult.RUNTIME_UI
+            sleep(0.5)
+        log.error(f"启动等待主界面超时（{timeout_seconds}秒）")
+        if not allow_restart:
+            return StartupMainMenuWaitResult.TIMEOUT
+        retries += 1
+        if retries > max_retries:
+            log.error(f"启动等待主界面已重试 {max_retries} 次仍超时，放弃重试")
+            return StartupMainMenuWaitResult.TIMEOUT
+        from tasks.base.retry import kill_game
+        from tasks.base.script_task_scheme import init_game
+
+        log.error("启动等待主界面超时，尝试重启游戏")
+        kill_game()
+        init_game()
 
 
 @begin_and_finish_time_log(task_name="返回主界面")

--- a/tasks/base/retry.py
+++ b/tasks/base/retry.py
@@ -14,6 +14,22 @@ from utils.utils import check_game_running
 
 _last_title_screen_tap_time = 0.0
 _last_simulator_alive_check_time = 0.0
+_pending_simulator_launch_probe = False
+
+
+def _get_simulator_connection_device():
+    if cfg.simulator_type == 0:
+        from module.automation.input_handlers.simulator.mumu_control import MumuControl
+
+        return MumuControl.connection_device
+
+    from module.automation.input_handlers.simulator.simulator_control import SimulatorControl
+
+    return SimulatorControl.connection_device
+
+
+def _is_main_menu_visible() -> bool:
+    return bool(auto.find_element("home/window_assets.png") and auto.find_element("home/mail_assets.png", model="normal"))
 
 
 def _is_runtime_ui_visible() -> bool:
@@ -24,12 +40,13 @@ def _is_runtime_ui_visible() -> bool:
         or auto.find_element("base/retry.png")
         or auto.find_element("base/try_again.png")
         or auto.find_element("home/back_assets.png", model="normal")
+        or auto.find_element("base/back_assets.png", model="normal", threshold=0.6)
         or auto.find_element("base/notification_close_assets.png")
         or auto.find_element("scenes/story_skip_confirm_assets.png")
         or auto.find_element("scenes/story_skip_assets.png")
         or auto.find_element("scenes/story_meun_assets.png")
         or auto.find_element("home/close_anniversary_event_assets.png")
-        or auto.find_element("mirror/road_in_mir/towindow&forfeit_confirm_assets.png")
+        or auto.find_element("mirror/road_in_mir/towindow&forfeit_confirm_assets.png", threshold=0.75)
         or auto.find_element("mirror/road_in_mir/to_window_assets.png", threshold=0.75)
         or auto.find_element("mirror/road_in_mir/select_encounter_reward_card_assets.png")
         or auto.find_element("mirror/road_in_mir/legend_assets.png")
@@ -38,9 +55,43 @@ def _is_runtime_ui_visible() -> bool:
     )
 
 
+def should_wait_for_main_menu_after_simulator_start() -> bool:
+    global _pending_simulator_launch_probe
+
+    if not _pending_simulator_launch_probe:
+        return False
+    _pending_simulator_launch_probe = False
+
+    from tasks.base.back_init_menu import handle_launch_state_once
+
+    deadline = time.time() + 3
+    had_model = hasattr(auto, "model")
+    previous_model = getattr(auto, "model", None)
+    auto.model = "clam"
+    try:
+        while time.time() <= deadline:
+            auto.ensure_not_stopped()
+            if auto.take_screenshot() is None:
+                continue
+            if _is_main_menu_visible():
+                return True
+            if handle_launch_state_once():
+                return True
+            if _is_runtime_ui_visible():
+                return False
+            sleep(0.5)
+    finally:
+        if had_model:
+            auto.model = previous_model
+
+    return True
+
+
 def ensure_simulator_game_started() -> bool:
     """模拟器模式下确认游戏仍在前台，不在时尝试拉起游戏。"""
-    global _last_simulator_alive_check_time
+    global _last_simulator_alive_check_time, _pending_simulator_launch_probe
+
+    _pending_simulator_launch_probe = False
     if not cfg.simulator:
         return False
 
@@ -49,19 +100,7 @@ def ensure_simulator_game_started() -> bool:
         return False
     _last_simulator_alive_check_time = now
 
-    if cfg.simulator_type == 0:
-        from module.automation.input_handlers.simulator.mumu_control import (
-            MumuControl,
-        )
-
-        connection_device = MumuControl.connection_device
-    else:
-        from module.automation.input_handlers.simulator.simulator_control import (
-            SimulatorControl,
-        )
-
-        connection_device = SimulatorControl.connection_device
-
+    connection_device = _get_simulator_connection_device()
     if connection_device is None:
         return False
 
@@ -70,6 +109,7 @@ def ensure_simulator_game_started() -> bool:
 
     log.info("检测到游戏未运行或不在前台，尝试自动启动游戏")
     connection_device.start_game()
+    _pending_simulator_launch_probe = True
     sleep(3)
     return True
 
@@ -165,7 +205,10 @@ def retry():
     while True:
         if ensure_simulator_game_started():
             start_time = time.time()
-            continue
+            if should_wait_for_main_menu_after_simulator_start():
+                from tasks.base.back_init_menu import wait_until_main_menu_after_launch
+
+                return wait_until_main_menu_after_launch() == "main_menu"
         if is_windows and screen.handle.hwnd != saved_hwnd:
             # 句柄发生变化则重置初始时间, 以免误判卡死
             saved_hwnd = screen.handle.hwnd
@@ -208,11 +251,11 @@ def retry():
         break
 
 
-def restart_game():
+def restart_game() -> bool:
     """重启游戏"""
-    from tasks.base.back_init_menu import back_init_menu
+    from tasks.base.back_init_menu import wait_until_main_menu_after_launch
     from tasks.base.script_task_scheme import init_game
 
     init_game()
     sleep(3)
-    back_init_menu()
+    return wait_until_main_menu_after_launch() == "main_menu"

--- a/tasks/base/retry.py
+++ b/tasks/base/retry.py
@@ -16,6 +16,28 @@ _last_title_screen_tap_time = 0.0
 _last_simulator_alive_check_time = 0.0
 
 
+def _is_runtime_ui_visible() -> bool:
+    return bool(
+        auto.find_element("battle/setting_assets.png")
+        or auto.find_element("battle/battle_finish_confirm_assets.png")
+        or auto.find_element("base/retry_countdown.png")
+        or auto.find_element("base/retry.png")
+        or auto.find_element("base/try_again.png")
+        or auto.find_element("home/back_assets.png", model="normal")
+        or auto.find_element("base/notification_close_assets.png")
+        or auto.find_element("scenes/story_skip_confirm_assets.png")
+        or auto.find_element("scenes/story_skip_assets.png")
+        or auto.find_element("scenes/story_meun_assets.png")
+        or auto.find_element("home/close_anniversary_event_assets.png")
+        or auto.find_element("mirror/road_in_mir/towindow&forfeit_confirm_assets.png")
+        or auto.find_element("mirror/road_in_mir/to_window_assets.png", threshold=0.75)
+        or auto.find_element("mirror/road_in_mir/select_encounter_reward_card_assets.png")
+        or auto.find_element("mirror/road_in_mir/legend_assets.png")
+        or auto.find_element("mirror/road_to_mir/enter_assets.png")
+        or auto.find_element("mirror/theme_pack/feature_theme_pack_assets.png")
+    )
+
+
 def ensure_simulator_game_started() -> bool:
     """模拟器模式下确认游戏仍在前台，不在时尝试拉起游戏。"""
     global _last_simulator_alive_check_time

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -354,10 +354,7 @@ def script_task() -> None | int:
         get_reward = battle.fight()
     else:
         startup_wait_result = wait_until_main_menu_after_launch(allow_restart=True)
-        if startup_wait_result == StartupMainMenuWaitResult.RUNTIME_UI:
-            if not back_init_menu():
-                raise cannotOperateGameError("启动后未能进入主界面，请手动检查后重试")
-        elif startup_wait_result == StartupMainMenuWaitResult.TIMEOUT:
+        if startup_wait_result == StartupMainMenuWaitResult.TIMEOUT:
             raise cannotOperateGameError("启动等待主界面超时，请手动检查后重试")
 
     task_list = []

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -346,6 +346,9 @@ def script_task() -> None | int:
     auto.clear_img_cache()
     log.debug(f"初始化图片路径: {path_manager.pic_path}")
 
+    if cfg.resonate_with_Ahab:
+        Resonate_with_Ahab()
+
     get_reward = None
     if auto.click_element("battle/turn_assets.png", take_screenshot=True):
         get_reward = battle.fight()
@@ -356,11 +359,6 @@ def script_task() -> None | int:
                 raise cannotOperateGameError("启动后未能进入主界面，请手动检查后重试")
         elif startup_wait_result == StartupMainMenuWaitResult.TIMEOUT:
             raise cannotOperateGameError("启动等待主界面超时，请手动检查后重试")
-        elif startup_wait_result != StartupMainMenuWaitResult.MAIN_MENU:
-            raise cannotOperateGameError("启动后主界面状态未知，请手动检查后重试")
-
-    if cfg.resonate_with_Ahab:
-        Resonate_with_Ahab()
 
     task_list = []
     # 执行日常刷本任务

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -30,7 +30,11 @@ from module.system_actions import (
     execute_after_completion,
     get_after_completion_config,
 )
-from tasks.base.back_init_menu import back_init_menu
+from tasks.base.back_init_menu import (
+    StartupMainMenuWaitResult,
+    back_init_menu,
+    wait_until_main_menu_after_launch,
+)
 from tasks.base.make_enkephalin_module import (
     lunacy_to_enkephalin,
     make_enkephalin_module,
@@ -342,13 +346,21 @@ def script_task() -> None | int:
     auto.clear_img_cache()
     log.debug(f"初始化图片路径: {path_manager.pic_path}")
 
-    if cfg.resonate_with_Ahab:
-        Resonate_with_Ahab()
-
-    # 如果是战斗中，先处理战斗
     get_reward = None
     if auto.click_element("battle/turn_assets.png", take_screenshot=True):
         get_reward = battle.fight()
+    else:
+        startup_wait_result = wait_until_main_menu_after_launch(allow_restart=True)
+        if startup_wait_result == StartupMainMenuWaitResult.RUNTIME_UI:
+            if not back_init_menu():
+                raise cannotOperateGameError("启动后未能进入主界面，请手动检查后重试")
+        elif startup_wait_result == StartupMainMenuWaitResult.TIMEOUT:
+            raise cannotOperateGameError("启动等待主界面超时，请手动检查后重试")
+        elif startup_wait_result != StartupMainMenuWaitResult.MAIN_MENU:
+            raise cannotOperateGameError("启动后主界面状态未知，请手动检查后重试")
+
+    if cfg.resonate_with_Ahab:
+        Resonate_with_Ahab()
 
     task_list = []
     # 执行日常刷本任务

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -30,11 +30,7 @@ from module.system_actions import (
     execute_after_completion,
     get_after_completion_config,
 )
-from tasks.base.back_init_menu import (
-    StartupMainMenuWaitResult,
-    back_init_menu,
-    wait_until_main_menu_after_launch,
-)
+from tasks.base.back_init_menu import back_init_menu
 from tasks.base.make_enkephalin_module import (
     lunacy_to_enkephalin,
     make_enkephalin_module,
@@ -352,10 +348,6 @@ def script_task() -> None | int:
     get_reward = None
     if auto.click_element("battle/turn_assets.png", take_screenshot=True):
         get_reward = battle.fight()
-    else:
-        startup_wait_result = wait_until_main_menu_after_launch(allow_restart=True)
-        if startup_wait_result == StartupMainMenuWaitResult.TIMEOUT:
-            raise cannotOperateGameError("启动等待主界面超时，请手动检查后重试")
 
     task_list = []
     # 执行日常刷本任务


### PR DESCRIPTION
## 功能

新增 PC 和模拟器两种场景下启动游戏后等待主界面的超时时间自定义配置：

- `startup_wait_timeout_pc`（默认 120 秒）
- `startup_wait_timeout_simulator`（默认 180 秒）

## 改动

### 新增配置项

- `ConfigModel` 新增两个字段
- `config.example.yaml` 新增对应键
- 设置界面在模拟器组和启动游戏组分别新增配置卡片

### 新增并加固 `wait_until_main_menu_after_launch`

使用 deadline 替代固定循环次数，在配置的超时时间内等待主界面出现。期间处理清缓存、连接中、等待中、单选项弹窗等启动过渡状态。

返回 `StartupMainMenuWaitResult`：

- `MAIN_MENU`：成功到达主界面
- `RUNTIME_UI`：检测到运行时 UI（战斗、镜牢、剧情、返回按钮等），交由现有任务/恢复流程继续处理
- `TIMEOUT`：禁用内部重启时等待超时

补充内容：

- 运行时 UI 统一通过 `_is_runtime_ui_visible()` 识别
- 截屏冻结时跳过误触，并尝试 `ESC` 导航兜底
- 镜牢入口等子界面不再被当成“继续等主界面”的未知画面
- `allow_restart=True` 时超时后重启游戏并重新等待，不再固定 3 次后放弃

### 启动/恢复流程调整

- `script_task()` 不再在普通非战斗界面强制等待主界面，避免从镜牢入口、主题卡包选择、寻路等子界面启动时卡住。
- 仍保留“如果启动时已经在战斗中，先恢复战斗”的逻辑。
- `retry()` / `back_init_menu()` / `restart_game()` 在模拟器实际拉起游戏后进行短探测：如果仍处于启动链路，则进入 `wait_until_main_menu_after_launch()` 并吃到自定义超时；如果已经是运行时 UI，则回到任务/恢复流程处理。

## 验证

- `uv run python -m py_compile app\setting_interface.py module\config\config_typing.py tasks\base\back_init_menu.py tasks\base\retry.py tasks\base\script_task_scheme.py` 通过
- `uv run ruff check module\config\config_typing.py tasks\base\back_init_menu.py tasks\base\retry.py tasks\base\script_task_scheme.py` 通过
- `git diff --check upstream/main..HEAD` 通过
- 包含 `app\setting_interface.py` 的 ruff 检查仍会命中 upstream/main 已存在的 `F841 bar`，本 PR 未处理该无关遗留警告

## 关联

Close: #752
Close: #747

建议先合并 #758，保证 `begin_and_finish_time_log` 不再吞掉 `back_init_menu()` 等函数的真实返回值。
