### PR TITLE
fix: 修复再次领取奖励重复收取邮箱

### DIFF
--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -317,9 +317,11 @@ def Mirror_task():
             mediator.mirror_signal.emit(finish_times, mir_times)
             msg = f"已完成 {finish_times} 次镜牢"
             log.info(msg)
+            if finish_times == 1 and cfg.re_claim_rewards:  # 完成第一次镜牢后重新领取奖励
+                to_get_reward()
 
     mediator.mirror_bar_kill_signal.emit()
-    if cfg.re_claim_rewards and finish_times > 0:
+    if cfg.re_claim_rewards and finish_times > 1:
         to_get_reward()
 
 

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -317,8 +317,6 @@ def Mirror_task():
             mediator.mirror_signal.emit(finish_times, mir_times)
             msg = f"已完成 {finish_times} 次镜牢"
             log.info(msg)
-            if finish_times == 1 and cfg.re_claim_rewards:  # 完成第一次镜牢后重新领取奖励
-                to_get_reward()
 
     mediator.mirror_bar_kill_signal.emit()
     if cfg.re_claim_rewards and finish_times > 0:


### PR DESCRIPTION
## 问题

勾选「再次领取奖励」后，完成镜牢时 	o_get_reward()（收取邮箱）会被调用两次，导致多收取一次。

## 根因

Mirror_task() 中存在两处 
e_claim_rewards 触发的 	o_get_reward() 调用：

1. **循环内**（inish_times == 1）：第一次镜牢完成后立即领取
2. **循环后**（inish_times > 0）：全部镜牢结束后再领一次

完成 ≥1 次镜牢时两个条件同时为真，收取邮箱 被执行两次。

```python
if finish_times == 1 and cfg.re_claim_rewards:  # 完成第一次镜牢后重新领取奖励
    to_get_reward()

mediator.mirror_bar_kill_signal.emit()
if cfg.re_claim_rewards and finish_times > 0:
    to_get_reward()
```

## 修复

删除循环内 inish_times == 1 的重复调用，保留循环后 inish_times > 0 的调用——「再次领取」应在全部镜牢结束后执行一次。

## 验证

- py_compile 通过
- 
uff check 通过