### PR TITLE
fix: 修改纽本特征阈值，使900P等分辨率能够正常匹配

### DIFF
--- a/tasks/daily/luxcavation.py
+++ b/tasks/daily/luxcavation.py
@@ -152,7 +152,7 @@ def thread_luxcavation(combat_count: int = 1):
             auto.find_element("home/first_prompt_assets.png", model="clam")
             and auto.find_element("home/back_assets.png", model="normal")
             and not auto.find_element("luxcavation/thread_enter_assets.png", threshold=0.78)
-            and not auto.find_element("luxcavation/thread_consume.png", threshold=0.85)
+            and not auto.find_element("luxcavation/thread_consume.png")
         ):
             auto.key_press("esc")
             continue
@@ -165,7 +165,7 @@ def thread_luxcavation(combat_count: int = 1):
                 continuous_combat_set = True
             auto.mouse_click(thread_enter[0], thread_enter[1])
             sleep(0.5)
-            if pos := auto.find_element("luxcavation/thread_consume.png", threshold=0.85,take_screenshot=True):
+            if pos := auto.find_element("luxcavation/thread_consume.png", take_screenshot=True):
                 if scroll_bar := auto.find_element("luxcavation/thread_scroll_bar.png"):
                     auto.mouse_drag_down(scroll_bar[0], scroll_bar[1], reverse=2)
                 else:


### PR DESCRIPTION
## 修复内容

移除 `tasks/daily/luxcavation.py` 中两处 `thread_consume.png` 匹配的显式 `threshold=0.85`，改用 `find_element` 默认阈值（0.8），使 900P 等分辨率能够正常匹配纽本消耗界面。

fix: #751

## 问题原因

在 900P 等分辨率下，`thread_consume.png` 的匹配相似度低于 0.85 但高于默认阈值 0.8，导致脚本无法识别纽本消耗界面。脚本误判未进入关卡列表，循环点击"纺锤"按钮。

## 变更

```diff
-            and not auto.find_element("luxcavation/thread_consume.png", threshold=0.85)
+            and not auto.find_element("luxcavation/thread_consume.png")
```

```diff
-            if pos := auto.find_element("luxcavation/thread_consume.png", threshold=0.85,take_screenshot=True):
+            if pos := auto.find_element("luxcavation/thread_consume.png", take_screenshot=True):
```

仅修改 `tasks/daily/luxcavation.py`，1 file changed, 2 insertions(+), 2 deletions(-)。