### PR TITLE
fix(mirror): 调整 re_start 检测顺序，避免 battle/give_up_assets 被 setting_assets 拦截

### DIFF
--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -1136,9 +1136,9 @@ class Mirror:
                 break
             if auto.click_element("mirror/road_in_mir/forfeit_assets.png"):
                 continue
-            if auto.click_element("mirror/road_in_mir/setting_assets.png"):
-                continue
             if auto.click_element("battle/give_up_assets.png"):
+                continue
+            if auto.click_element("mirror/road_in_mir/setting_assets.png"):
                 continue
             auto.key_press("esc")
             time.sleep(1)


### PR DESCRIPTION
## 问题

`re_start()` 中 `mirror/road_in_mir/setting_assets.png`（齿轮）的检查排在 `battle/give_up_assets.png`（战斗放弃）之前。在战斗场景中，齿轮每次匹配成功（相似度 0.806）后立即 `continue` 回到循环开头，导致 `give_up_assets` 永远无法被执行。

效果是点击齿轮打开菜单后，反复开关菜单（齿轮每次 toggle），形成死循环。

## 修复

交换两块代码的顺序，使 `battle/give_up_assets.png` 优先于 `mirror/road_in_mir/setting_assets.png` 检测。

```
- setting_assets -> continue
- give_up_assets -> continue
+ give_up_assets -> continue
+ setting_assets -> continue
```

## 变更

`tasks/mirror/mirror.py` -- 4 行交换，无其他改动。