### PR TITLE
feat: 添加简单键盘寻路模式并统一键盘寻路成功检测

### DIFF
--- a/app/page_card.py
+++ b/app/page_card.py
@@ -498,6 +498,12 @@ class PageMirror(PageCard):
             QT_TRANSLATE_NOOP("BaseCheckBox", "使用键盘进行镜牢寻路"),
             center=False,
         )
+        self.mirror_keyboard_simple_pathfinding = BaseCheckBox(
+            "mirror_keyboard_simple_pathfinding",
+            None,
+            QT_TRANSLATE_NOOP("BaseCheckBox", "简单键盘寻路（始终按↑键，避免鼠标拖动）"),
+            center=False,
+        )
 
     def __init_layout(self):
         self.vbox_general.addWidget(self.team)
@@ -517,6 +523,7 @@ class PageMirror(PageCard):
         self.vbox_advanced.addWidget(self.not_skip_whitegossypium)
         self.vbox_advanced.addWidget(self.fight_to_last_man)
         self.vbox_advanced.addWidget(self.mirror_keyboard_navigation)
+        self.vbox_advanced.addWidget(self.mirror_keyboard_simple_pathfinding)
 
         self.card_layout.insertWidget(self.card_layout.count() - 1, self.mirror_count)
 
@@ -793,6 +800,7 @@ class PageMirror(PageCard):
         self.not_skip_whitegossypium.retranslateUi()
         self.fight_to_last_man.retranslateUi()
         self.mirror_keyboard_navigation.retranslateUi()
+        self.mirror_keyboard_simple_pathfinding.retranslateUi()
         self.add_team_button.setToolTip(self.tr("添加队伍"))
         for child in self.findChildren(MirrorTeamCombination):
             child.retranslateUi()

--- a/app/page_card.py
+++ b/app/page_card.py
@@ -505,6 +505,16 @@ class PageMirror(PageCard):
             center=False,
         )
 
+        self.mirror_keyboard_navigation.check_box.toggled.connect(
+            self._on_keyboard_navigation_toggled
+        )
+        self._on_keyboard_navigation_toggled(cfg.mirror_keyboard_navigation)
+
+    def _on_keyboard_navigation_toggled(self, checked: bool):
+        if not checked and cfg.mirror_keyboard_simple_pathfinding:
+            self.mirror_keyboard_simple_pathfinding.set_check_false()
+        self.mirror_keyboard_simple_pathfinding.set_box_enabled(checked)
+
     def __init_layout(self):
         self.vbox_general.addWidget(self.team)
 

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -137,6 +137,7 @@ teams_be_select_num: 0 # 被选中的队伍数量
 teams_be_select: [False] # 被选中的队伍
 teams_order: [0] # 队伍的顺序
 mirror_keyboard_navigation: False # 使用键盘进行镜牢寻路
+mirror_keyboard_simple_pathfinding: False # 简单键盘寻路（始终按↑，避免鼠标拖动）
 
 # 队伍设置
 teams_active_queue: [] # 镜牢启用队伍的执行队列（单一事实源）

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -517,6 +517,9 @@ class ConfigModel(BaseModel):
     mirror_keyboard_navigation: bool
     """使用键盘进行镜牢寻路"""
 
+    mirror_keyboard_simple_pathfinding: bool
+    """简单键盘寻路模式：始终按↑选择第一个节点，完全避免鼠标拖动"""
+
     teams: dict[str, TeamSetting]
     """队伍设置"""
 

--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -28,6 +28,7 @@ from tasks.mirror.search_road import (
     MirrorMap,
     search_road_default_distance,
     search_road_farthest_distance,
+    search_road_simple_keyboard,
 )
 from tasks.mirror.select_theme_pack import select_theme_pack
 from tasks.teams.team_formation import check_team, load_team_code_in_game, select_battle_team, team_formation
@@ -1058,6 +1059,11 @@ class Mirror:
 
     @begin_and_finish_time_log(task_name="镜牢寻路")
     def search_road(self):
+        if cfg.mirror_keyboard_simple_pathfinding:
+            if search_road_simple_keyboard():
+                return True
+            log.debug("简单键盘寻路失败，回退到常规寻路")
+
         try:
             if next_node := self.mirror_map.get_next_step():
                 if next_node is True:

--- a/tasks/mirror/search_road.py
+++ b/tasks/mirror/search_road.py
@@ -54,9 +54,7 @@ class MirrorMap:
             sleep(0.5)
             auto.key_press("enter")
             sleep(1.25)
-            if auto.click_element("mirror/road_in_mir/enter_assets.png", take_screenshot=True):
-                return True
-            return True
+            return _keyboard_enter_succeeded()
 
         if next_position := self._get_next_position(next_step):
             auto.mouse_click(next_position[0], next_position[1])
@@ -121,6 +119,45 @@ def get_node_weight(x, y):
     elif auto.find_feature_element("mirror/road_in_mir/hard_battle2.png", road_node_bbox):
         return 0
     return -5
+
+
+def _keyboard_enter_succeeded() -> bool:
+    """检测键盘寻路按键后是否成功进入下一节点。
+
+    成功条件：点击到"进入"按钮，或地图图例消失（已离开节点选择界面）。
+    """
+    if auto.click_element("mirror/road_in_mir/enter_assets.png", take_screenshot=True):
+        return True
+    if not auto.find_element("mirror/road_in_mir/legend_assets.png"):
+        return True
+    return False
+
+
+# 简单键盘寻路：始终按↑选择第一个节点，完全避免鼠标拖动
+def search_road_simple_keyboard():
+    """最简单寻路策略：不进行路线规划/相机对齐/节点识别，仅按↑键选择第一个节点后回车。
+
+    适用于 Steam 环境下鼠标拖动地图导致卡死的场景，依赖 mirror_keyboard_navigation。
+    """
+    if not cfg.mirror_keyboard_navigation:
+        log.warning("简单键盘寻路需要启用键盘寻路模式")
+        return False
+
+    auto.mouse_to_blank()
+    sleep(0.3)
+
+    for attempt in range(2):
+        log.debug(f"简单键盘寻路: 第 {attempt + 1} 次尝试按↑+回车")
+        auto.key_press("up")
+        sleep(0.5)
+        auto.key_press("enter")
+        sleep(1.25)
+
+        if _keyboard_enter_succeeded():
+            return True
+
+    log.debug("简单键盘寻路失败，需回退到常规寻路")
+    return False
 
 
 # 在默认缩放情况下，进行镜牢寻路


### PR DESCRIPTION
## 变更内容

新增镜牢简单键盘寻路模式，并统一键盘寻路的成功检测逻辑。

### 新增功能

- **`mirror_keyboard_simple_pathfinding` 配置项与 UI 复选框**：启用后跳过路线规划/节点识别，仅按↑选择第一个节点后回车。适用于 Steam 环境下鼠标拖动地图导致卡死的场景，失败时自动回退到常规寻路。
- **`search_road_simple_keyboard()`**：实现上述盲按策略，最多重试 2 次。

### 改进

- **提取 `_keyboard_enter_succeeded()` 共通检测函数**：通过点击"进入"按钮成功或地图图例消失判断是否进入下一节点。
- **`MirrorMap.enter_next_node` 键盘分支不再无脑返回 `True`**：改为调用 `_keyboard_enter_succeeded()`，失败时返回 `False`，使常规键盘寻路也能降级到鼠标寻路。

## 改动文件

| 文件 | 说明 |
|---|---|
| `tasks/mirror/search_road.py` | 新增 `_keyboard_enter_succeeded()` 和 `search_road_simple_keyboard()`；`enter_next_node` 键盘分支改用共通检测 |
| `tasks/mirror/mirror.py` | `search_road()` 开头增加简单键盘寻路调用与回退 |
| `module/config/config_typing.py` | 新增 `mirror_keyboard_simple_pathfinding` 字段 |
| `app/page_card.py` | 新增 UI 复选框与 retranslateUi |
| `assets/config/config.example.yaml` | 新增配置项示例 |

## 预览
`坐牢设置` - `高级设置`
<img width="314" height="58" alt="image" src="https://github.com/user-attachments/assets/e2e01087-1f0f-4ab2-a029-dc3b9af9338f" />
注：开启键盘寻路后才能勾选简易寻路，关闭镜牢寻路后应该会同步关闭简易寻路

## 验证

- `py_compile` 通过
- `ruff check` 无新增警告
- 依赖的 API（`auto.mouse_to_blank`、`auto.key_press`、`auto.click_element`、`auto.find_element`）及图片资源（`enter_assets.png`、`legend_assets.png`）均存在于上游 main

## issue
close: #764