### PR TITLE
fix: 狂气换体后体力OCR出错

### DIFF
--- a/tasks/base/make_enkephalin_module.py
+++ b/tasks/base/make_enkephalin_module.py
@@ -36,6 +36,8 @@ def get_the_timing(return_time=False):
 
 
 def get_current_enkephalin():
+    import re
+
     import cv2
     import numpy as np
 
@@ -48,27 +50,23 @@ def get_current_enkephalin():
             while auto.take_screenshot() is None:
                 continue
             sc = ImageUtils.crop(np.array(auto.screenshot), enkephalin_bbox)
-            _, binary_image = cv2.threshold(sc, 110, 255, cv2.THRESH_BINARY)
-            result = ocr.run(binary_image)
-            ocr_result = [result.txts[i] for i in range(len(result.txts))]
-            ocr_result = "".join(ocr_result)
-            ocr_result = ocr_result.lower()
-            if "/" in ocr_result:
-                ocr_result = ocr_result.split("/")
-                current_enkephalin = int(ocr_result[0])
-                return current_enkephalin
-        except:
+            # RapidOCR 容易漏掉紧贴裁剪边缘的体力数字，补黑边只影响本处 OCR 输入。
+            sc = cv2.copyMakeBorder(sc, 16, 16, 16, 16, cv2.BORDER_CONSTANT, value=0)
+            for threshold in (100, 110, 70, 60):
+                _, binary_image = cv2.threshold(sc, threshold, 255, cv2.THRESH_BINARY)
+                result = ocr.run(binary_image)
+                ocr_result = "".join(str(t) for t in result.txts or [])
+                ocr_result = ocr_result.lower().replace(" ", "")
+                if "/" in ocr_result:
+                    match = re.search(r"(\d{1,3})\s*/\s*\d{3,4}", ocr_result)
+                    if match:
+                        return int(match.group(1))
+                else:
+                    digits = re.sub(r"\D", "", ocr_result)
+                    if 0 < len(digits) <= 3:
+                        return int(digits)
+        except Exception:
             continue
-    try:
-        sc = ImageUtils.crop(np.array(auto.screenshot), enkephalin_bbox)
-        _, binary_image = cv2.threshold(sc, 150, 255, cv2.THRESH_BINARY)
-        result = ocr.run(binary_image)
-        ocr_result = [result.txts[i] for i in range(len(result.txts))]
-        ocr_result = "".join(ocr_result)
-        current_enkephalin = int(ocr_result[0])
-        return current_enkephalin
-    except:
-        pass
     return None
 
 


### PR DESCRIPTION
RapidOCR 容易漏掉紧贴裁剪边缘的左侧数字，使 `get_current_enkephalin()`
只读到 `/xxx` 然后 `int("")` 抛异常，或读取到不完整结果。

- 在 OCR 裁剪区域四周添加 16px 黑边补丁 (`cv2.copyMakeBorder`)
- 降低二值化阈值（110/150 → 70/60），适应体力数字可能较淡的情况
- 改用正则 `(\d{1,3})\s*/` 提取斜杠前的数值，避免空字符串
- 新增无斜杠时的纯数字兜底提取
- 移除粗暴的回退 `int(ocr_result[0])` 逻辑