### PR TITLE
fix: 兼容 MuMu12 v6.2.2 的 NemuIpc DLL 路径和启动状态检测

### DIFF
--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -661,7 +661,7 @@ class MumuControl(AbstractInput):
             log.error("以下路径均不存在")
             for path in list_dll:
                 log.error(f"{path}")
-            raise NemuIpcIncompatible("请在AALC设置中检查您的MuMu播放器12版本和安装路径。")
+            raise NemuIpcIncompatible("请在AALC设置中检查您的MuMu模拟器12版本和安装路径。")
         else:
             log.debug(f"ipc_dll={ipc_dll} 加载成功")
 

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -621,18 +621,30 @@ class MumuControl(AbstractInput):
         )
         info = json.loads(proc.stdout)
         try:
-            return info["player_state"]
-        except:
+            if "player_state" in info:
+                return info["player_state"]
+            if info.get("is_android_started") or info.get("is_process_started"):
+                return "start_finished"
+            return "not_launched"
+        except Exception:
+            log.warning(f"get_launch_status: 解析 info 失败，无法获取启动状态，stdout={proc.stdout}")
             return "not_launched"
 
     def load_dll(self):
         nemu_folder = os.path.dirname(self.install_path)
         list_dll = [
-            # MuMuPlayer12
             os.path.abspath(os.path.join(nemu_folder, "./shell/sdk/external_renderer_ipc.dll")),
-            # MuMuPlayer12 5.0
             os.path.abspath(os.path.join(nemu_folder, "./nx_device/12.0/shell/sdk/external_renderer_ipc.dll")),
         ]
+        lib_path = self.get_nemu_client_path()
+        if lib_path:
+            list_dll.append(os.path.abspath(lib_path))
+        nx_device_root = os.path.join(nemu_folder, "nx_device")
+        if os.path.isdir(nx_device_root):
+            for entry in sorted(os.listdir(nx_device_root)):
+                candidate = os.path.join(nx_device_root, entry, "shell", "sdk", "external_renderer_ipc.dll")
+                if os.path.exists(candidate):
+                    list_dll.append(os.path.abspath(candidate))
         ipc_dll = ""
         for ipc_dll in list_dll:
             if not os.path.exists(ipc_dll):


### PR DESCRIPTION
修复 MuMu12 v6.2.2（Android 15）连接失败的两个问题：

### 1. `load_dll` — DLL 路径搜索缺失
`load_dll()` 只搜索了 `shell/sdk/` 和 `nx_device/12.0/shell/sdk/` 两条旧路径。
v6.2.2 的 DLL 位于 `nx_main/sdk/` 和 `nx_device/15.0/shell/sdk/`。

**修复**: 
- 新增 `get_nemu_client_path()` 计算结果（覆盖 `nx_main/sdk/`）
- 动态扫描 `nx_device/*/shell/sdk/`，自动匹配 12.0、15.0 及未来 Android 版本

### 2. `get_launch_status` — 新版 JSON 格式不兼容
v6.2.2 的 `MuMuManager.exe info -v 0` 不再返回 `player_state` 字段，改用 `is_android_started` / `is_process_started` 布尔值。

**修复**:
- 优先检查 `player_state`（旧版兼容）
- 回退检查 `is_android_started` / `is_process_started`（新版）
- 解析异常时增加日志输出以便排查

### 验证
- 启动检测：~3 秒正确返回 `start_finished`（旧版 30 秒超时）
- DLL 加载：`nx_main\sdk\external_renderer_ipc.dll` 加载成功
- NemuIpc 连接、截图、点击、滑动均正常