### PR TITLE
fix: 修复后台截图时未判断所取句柄是否为空导致的无限循环截图

### DIFF
--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -295,6 +295,7 @@ class Automation(metaclass=SingletonMeta):
                 from tasks.base.script_task_scheme import init_game
 
                 init_game()
+                start_time = time.time()
 
     def find_element(
         self,

--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -11,7 +11,6 @@ import numpy as np
 import psutil
 from PIL.Image import Image
 
-from module.my_error.my_error import withOutGameWinError
 from utils.image_utils import ImageUtils
 from utils.path_manager import path_manager
 from utils.singletonmeta import SingletonMeta
@@ -261,7 +260,6 @@ class Automation(metaclass=SingletonMeta):
         """
         start_time = time.time()
         screenshot_interval_time = cfg.screenshot_interval if cfg.screenshot_interval else 0.85
-        is_game_die = False
         while True:
             try:
                 if time.time() - self.last_screenshot_time < screenshot_interval_time:
@@ -278,13 +276,10 @@ class Automation(metaclass=SingletonMeta):
                     return result
                 else:
                     return None
-            except withOutGameWinError as e:
-                log.error(f"截图失败: {e}")
-                is_game_die = True
             except Exception as e:
                 log.error(f"截图失败:{e}")
             time.sleep(1)
-            if time.time() - start_time > 60 or is_game_die:
+            if time.time() - start_time > 60:
                 log.error("截图超时，尝试重启游戏")
                 import os
 
@@ -300,8 +295,6 @@ class Automation(metaclass=SingletonMeta):
                 from tasks.base.script_task_scheme import init_game
 
                 init_game()
-                is_game_die = False
-                start_time = time.time()
 
     def find_element(
         self,

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -750,19 +750,22 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         else:
             dx = 0
             dy = 0
-        win32gui.SetWindowPos(
-            hwnd,
-            None,
-            mouse_pos[0] - x + dx,
-            mouse_pos[1] - y + dy,
-            0,
-            0,
-            win32con.SWP_NOSIZE
-            | win32con.SWP_NOZORDER
-            | win32con.SWP_NOACTIVATE
-            | win32con.SWP_NOSENDCHANGING
-            | win32con.SWP_NOREDRAW,
-        )
+        try:
+            win32gui.SetWindowPos(
+                hwnd,
+                None,
+                mouse_pos[0] - x + dx,
+                mouse_pos[1] - y + dy,
+                0,
+                0,
+                win32con.SWP_NOSIZE
+                | win32con.SWP_NOZORDER
+                | win32con.SWP_NOACTIVATE
+                | win32con.SWP_NOSENDCHANGING
+                | win32con.SWP_NOREDRAW,
+            )
+        except Exception as e:
+            log.error(f"窗口移动点击时移动窗口失败: {e}")
 
         return original_rect[:2]
 

--- a/module/automation/screenshot.py
+++ b/module/automation/screenshot.py
@@ -11,6 +11,7 @@ from PIL import Image
 from module.config import cfg
 from module.game_and_screen import screen
 from module.logger import log
+from module.my_error.my_error import withOutGameWinError
 
 
 class ScreenShot:
@@ -182,6 +183,8 @@ class ScreenShot:
         try:
             # 查找游戏窗口句柄
             hwnd = screen.handle.hwnd
+            if hwnd == 0:
+                raise withOutGameWinError("未找到游戏窗口句柄，无法截图")
             if screen.handle.isMinimized:
                 raise ValueError("窗口最小化，无法截图")
             elif screen.handle.isActive and screen.handle.isTransparent:
@@ -228,7 +231,7 @@ class ScreenShot:
 
             return pil_image
 
-        except pywintypes.error as e:
+        except (pywintypes.error, withOutGameWinError) as e:
             log.error(f"后台截图报错: {e}，尝试重启游戏")
             import os
 

--- a/module/game_and_screen/screen.py
+++ b/module/game_and_screen/screen.py
@@ -8,7 +8,6 @@ import win32gui
 from app import mediator
 from module.config import cfg
 from module.logger import log
-from module.my_error.my_error import withOutGameWinError
 from utils.singletonmeta import SingletonMeta
 
 if TYPE_CHECKING:
@@ -24,9 +23,7 @@ class Handle:
     def __init__(self):
         self._enum_windows_list = []
 
-    def init_handle(
-        self, title: str = "LimbusCompany", class_name: str = "UnityWndClass", add_stacklevel: int = 0
-    ) -> int:
+    def init_handle(self, title: str = "LimbusCompany", class_name: str = "UnityWndClass") -> int:
         """获取窗口句柄"""
         hwnd = win32gui.FindWindow(class_name, title)
         if hwnd:
@@ -39,27 +36,23 @@ class Handle:
             except win32gui.error:
                 pass
             except Exception as e:
-                log.error(f"枚举窗口时发生错误: {e}", stacklevel=3 + add_stacklevel)
+                log.error(f"枚举窗口时发生错误: {e}", stacklevel=3)
             if self._hwnd == 0:
-                log.error("未能获取到游戏窗口", stacklevel=3 + add_stacklevel)
+                log.error("未能获取到游戏窗口", stacklevel=3)
                 log.debug(f"枚举窗口列表: {self._enum_windows_list}")
                 self._enum_windows_list.clear()
-                raise withOutGameWinError("未能获取到游戏窗口")
         return self._hwnd
 
     def _enum_windows_callback(self, hwnd, _):
         """该函数于GUI线程中返回停止信号固定触发`win32gui.error`报错, 外部调用务必捕获异常, 以防崩溃"""
         class_name = win32gui.GetClassName(hwnd)
         window_text = win32gui.GetWindowText(hwnd)
-
+        self._enum_windows_list.append(f"hwnd: {hwnd}, class_name: {class_name}, window_text: {window_text}")
         if class_name == "UnityWndClass" and window_text == "LimbusCompany":
-            self._enum_windows_list.append(f"hwnd: {hwnd}, class_name: {class_name}, window_text: {window_text}")
             log.debug(f"在枚举窗口中找到匹配的窗口: {hwnd}", stacklevel=4)
             self._hwnd = hwnd
             self._enum_windows_list.clear()
             return False  # 停止枚举
-        elif class_name == "UnityWndClass" or window_text == "LimbusCompany":
-            self._enum_windows_list.append(f"hwnd: {hwnd}, class_name: {class_name}, window_text: {window_text}")
         return True  # 继续枚举
 
     @property
@@ -69,10 +62,10 @@ class Handle:
             if cfg.config.simulator:
                 log.debug("模拟器模式下无法获取窗口句柄", stacklevel=3)
             else:
-                self.init_handle(add_stacklevel=1)
+                self.init_handle()
         elif not win32gui.IsWindow(self._hwnd):
             log.warning(f"窗口句柄无效，可能窗口已关闭，重新获取, 当前句柄为 {self._hwnd}", stacklevel=3)
-            self.init_handle(add_stacklevel=1)
+            self.init_handle()
             if win32gui.IsWindow(self._hwnd):
                 log.info(f"重新获取窗口句柄成功, 新句柄为 {self._hwnd}", stacklevel=3)
         return self._hwnd

--- a/module/game_and_screen/screen.py
+++ b/module/game_and_screen/screen.py
@@ -69,16 +69,10 @@ class Handle:
             if cfg.config.simulator:
                 log.debug("模拟器模式下无法获取窗口句柄", stacklevel=3)
             else:
-                try:
-                    self.init_handle(add_stacklevel=1)
-                except withOutGameWinError:
-                    return 0
+                self.init_handle(add_stacklevel=1)
         elif not win32gui.IsWindow(self._hwnd):
             log.warning(f"窗口句柄无效，可能窗口已关闭，重新获取, 当前句柄为 {self._hwnd}", stacklevel=3)
-            try:
-                self.init_handle(add_stacklevel=1)
-            except withOutGameWinError:
-                return 0
+            self.init_handle(add_stacklevel=1)
             if win32gui.IsWindow(self._hwnd):
                 log.info(f"重新获取窗口句柄成功, 新句柄为 {self._hwnd}", stacklevel=3)
         return self._hwnd

--- a/module/game_and_screen/screen.py
+++ b/module/game_and_screen/screen.py
@@ -47,12 +47,15 @@ class Handle:
         """该函数于GUI线程中返回停止信号固定触发`win32gui.error`报错, 外部调用务必捕获异常, 以防崩溃"""
         class_name = win32gui.GetClassName(hwnd)
         window_text = win32gui.GetWindowText(hwnd)
-        self._enum_windows_list.append(f"hwnd: {hwnd}, class_name: {class_name}, window_text: {window_text}")
+
         if class_name == "UnityWndClass" and window_text == "LimbusCompany":
+            self._enum_windows_list.append(f"hwnd: {hwnd}, class_name: {class_name}, window_text: {window_text}")
             log.debug(f"在枚举窗口中找到匹配的窗口: {hwnd}", stacklevel=4)
             self._hwnd = hwnd
             self._enum_windows_list.clear()
             return False  # 停止枚举
+        elif class_name == "UnityWndClass" or window_text == "LimbusCompany":
+            self._enum_windows_list.append(f"hwnd: {hwnd}, class_name: {class_name}, window_text: {window_text}")
         return True  # 继续枚举
 
     @property


### PR DESCRIPTION
先前的修复位置及方法破坏性过大 修改为最小化更改形式