### PR TITLE
fix: 修复编队列表滑动误触队伍排序

### DIFF
--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -87,6 +87,7 @@ class Automation(metaclass=SingletonMeta):
         self.mouse_click = self.input_handler.mouse_click
         self.mouse_click_blank = self.input_handler.mouse_click_blank
         self.mouse_drag = self.input_handler.mouse_drag
+        self.mouse_swipe_for_scroll = self.input_handler.mouse_swipe_for_scroll
         self.mouse_drag_down = self.input_handler.mouse_drag_down
         self.mouse_scroll = self.input_handler.mouse_scroll
         self.set_pause = self.input_handler.set_pause

--- a/module/automation/input_handlers/__init__.py
+++ b/module/automation/input_handlers/__init__.py
@@ -66,6 +66,7 @@ class AbstractInput:
         """
         raise InterruptedError(f"未实现的输入方法 {self.__class__.__name__}.mouse_click_blank")
 
+    # 普通拖拽会在终点停留后再抬起，用于确实需要“拖住”的场景。
     def mouse_drag(self, x, y, drag_time=0.1, dx=0, dy=0, move_back=True) -> None:
         """鼠标从指定位置拖动到另一个位置
         Args:
@@ -77,6 +78,16 @@ class AbstractInput:
             move_back (bool): 是否在拖动后将鼠标移动回原位置
         """
         raise InterruptedError(f"未实现的输入方法 {self.__class__.__name__}.mouse_drag")
+
+    def mouse_swipe_for_scroll(self, x, y, duration=0.3, dx=0, dy=0, move_back=True) -> None:
+        """各输入适配器必须实现的列表滚动手势。
+
+        手势按下后快速脱离长按判定区域，并在到达终点后立即抬起。
+        此处是接口占位；实际输入由具体适配器实现。
+        """
+        raise InterruptedError(
+            f"输入适配器 {self.__class__.__name__} 未实现 mouse_swipe_for_scroll"
+        )
 
     def mouse_drag_down(self, x, y, reverse=1, move_back=True) -> None:
         """鼠标从指定位置向下拖动

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -15,6 +15,7 @@ from utils.singletonmeta import SingletonMeta
 from ...game_and_screen import screen
 from ...logger import log
 from . import AbstractInput
+from .scroll_swipe import build_scroll_swipe_plan
 
 key_list = {
     "a": 0x41,
@@ -202,6 +203,27 @@ class Input(WinAbstractInput, metaclass=SingletonMeta):
             sleep(drag_time * 0.3)
         else:
             sleep(0.5)
+        pyautogui.mouseUp()
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+    def mouse_swipe_for_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        plan = [
+            (self.pos_offset(*point), move_duration)
+            for point, move_duration in build_scroll_swipe_plan(
+                x, y, dx, dy, duration
+            )
+        ]
+        pyautogui.moveTo(*plan[0][0])
+        pyautogui.mouseDown()
+        for point, move_duration in plan[1:]:
+            pyautogui.moveTo(*point, duration=move_duration)
         pyautogui.mouseUp()
 
         if move_back and current_mouse_position:
@@ -396,6 +418,23 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
         else:
             sleep(0.5)
         self.mouse_up(x + dx, y + dy)
+
+        if move_back and current_mouse_position:
+            self.mouse_move(current_mouse_position)
+
+    def mouse_swipe_for_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        if move_back:
+            current_mouse_position = self.get_mouse_position()
+
+        plan = build_scroll_swipe_plan(x, y, dx, dy, duration)
+        self.set_mouse_pos(*plan[0][0])
+        self.set_active()
+        self.mouse_down(*plan[0][0])
+        for point, move_duration in plan[1:]:
+            self.set_mouse_pos(*point, duration=move_duration)
+        self.mouse_up(*plan[-1][0])
 
         if move_back and current_mouse_position:
             self.mouse_move(current_mouse_position)
@@ -661,6 +700,18 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         else:
             sleep(0.5)
         self.mouse_up(x + dx, y + dy)
+        screen.handle.set_window_pos(*pos)
+
+    def mouse_swipe_for_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        plan = build_scroll_swipe_plan(x, y, dx, dy, duration)
+        pos = self._set_window_pos(*plan[0][0])
+        self.set_active()
+        self.mouse_down(*plan[0][0])
+        for point, move_duration in plan[1:]:
+            self._window_move_to(*point, duration=move_duration)
+        self.mouse_up(*plan[-1][0])
         screen.handle.set_window_pos(*pos)
 
     def mouse_drag_down(self, x, y, reverse=1, move_back=True) -> None:

--- a/module/automation/input_handlers/scroll_swipe.py
+++ b/module/automation/input_handlers/scroll_swipe.py
@@ -1,0 +1,34 @@
+from math import hypot
+
+
+def build_scroll_swipe_plan(
+    x,
+    y,
+    dx=0,
+    dy=0,
+    duration=0.3,
+    escape_distance=30,
+    escape_duration=0,
+):
+    """生成规避长按判定的滚动路径，元素为（坐标，到达该点前的耗时）。
+
+    按下后先快速移动 ``escape_distance``，使游戏尽快离开长按判定区域，
+    再用剩余时间移动到终点。短距离滑动则直接移动到终点。
+    """
+    duration = max(0, duration)
+    distance = hypot(dx, dy)
+    start = (x, y)
+    end = (x + dx, y + dy)
+    if distance == 0:
+        return [(start, 0)]
+    if distance <= escape_distance:
+        return [(start, 0), (end, duration)]
+
+    ratio = escape_distance / distance
+    initial = (x + dx * ratio, y + dy * ratio)
+    initial_duration = min(escape_duration, duration)
+    return [
+        (start, 0),
+        (initial, initial_duration),
+        (end, duration - initial_duration),
+    ]

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -19,6 +19,7 @@ from module.my_error.my_error import userStopError
 from utils.utils import run_as_user
 
 from .. import AbstractInput
+from ..scroll_swipe import build_scroll_swipe_plan
 from . import insert_swipe
 
 usual_key_code = {
@@ -991,6 +992,16 @@ class MumuControl(AbstractInput):
         else:
             time.sleep(0.5)
 
+        self.up()
+
+    def mouse_swipe_for_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        plan = build_scroll_swipe_plan(x, y, dx, dy, duration)
+        self.down(*plan[0][0])
+        for point, segment_duration in plan[1:]:
+            time.sleep(segment_duration)
+            self.down(*point)
         self.up()
 
     def mouse_scroll(self, direction: int = -3) -> bool:

--- a/module/automation/input_handlers/simulator/pyminitouch/actions.py
+++ b/module/automation/input_handlers/simulator/pyminitouch/actions.py
@@ -181,6 +181,17 @@ class MNTDevice(object):
 
         _builder.publish(self.connection)
 
+    def _normalize_touch_coordinates(self, x, y):
+        """将屏幕像素坐标规格化为 minitouch 使用的整数坐标。"""
+        if (
+            int(self.connection.max_x) > 1440
+            and self.real_width != 0
+            and self.real_height != 0
+        ):
+            x = (x / self.real_width) * int(self.connection.max_x)
+            y = (y / self.real_height) * int(self.connection.max_y)
+        return int(x), int(y)
+
     def swipe(self, points, pressure=100, duration=None, no_down=None, no_up=None):
         """
         swipe between points, one by one
@@ -193,18 +204,6 @@ class MNTDevice(object):
         :return:
         """
 
-        def transform_xy(x, y):
-            """
-            将屏幕像素坐标转换为 Minitouch 逻辑坐标
-            """
-            if self.real_width == 0 or self.real_height == 0:
-                # Fallback if resolution fetching failed
-                return x, y
-            target_x = int((x / self.real_width) * int(self.connection.max_x))
-            target_y = int((y / self.real_height) * int(self.connection.max_y))
-
-            return target_x, target_y
-
         points = [list(map(int, each_point)) for each_point in points]
 
         _builder = CommandBuilder()
@@ -213,16 +212,14 @@ class MNTDevice(object):
         # tap the first point
         if not no_down:
             x, y = points.pop(0)
-            if int(self.connection.max_x) > 1440:
-                x, y = transform_xy(x, y)
+            x, y = self._normalize_touch_coordinates(x, y)
             _builder.down(point_id, x, y, pressure)
             _builder.publish(self.connection)
 
         # start swiping
         for each_point in points:
             x, y = each_point
-            if int(self.connection.max_x) > 1440:
-                x, y = transform_xy(x, y)
+            x, y = self._normalize_touch_coordinates(x, y)
             _builder.move(point_id, x, y, pressure)
 
             # add delay between points
@@ -236,6 +233,34 @@ class MNTDevice(object):
         if not no_up:
             _builder.up(point_id)
             _builder.publish(self.connection)
+
+    def _send_swipe_plan_in_one_batch(self, plan, pressure=100):
+        '''将滑动计划作为一批连续的按下、移动、抬起指令发送。'''
+        if not plan:
+            return
+
+        builder = CommandBuilder()
+        point_id = 0
+        (start_x, start_y), _ = plan[0]
+        builder.down(
+            point_id,
+            *self._normalize_touch_coordinates(start_x, start_y),
+            pressure,
+        )
+        builder.commit()
+
+        for (x, y), duration in plan[1:]:
+            if duration:
+                builder.wait(round(duration * 1000))
+            builder.move(
+                point_id,
+                *self._normalize_touch_coordinates(x, y),
+                pressure,
+            )
+            builder.commit()
+
+        builder.up(point_id)
+        builder.publish(self.connection)
 
     def up(self, contact_id: int = 0):
         """

--- a/module/automation/input_handlers/simulator/simulator_control.py
+++ b/module/automation/input_handlers/simulator/simulator_control.py
@@ -12,6 +12,7 @@ from module.config import cfg
 from module.logger import log
 
 from .. import AbstractInput
+from ..scroll_swipe import build_scroll_swipe_plan
 from .pyminitouch import MNTDevice
 
 T = TypeVar("T")
@@ -443,6 +444,34 @@ class SimulatorControl(AbstractInput):
             self.simulator_control.up()
 
         self._call_with_reconnect("滑动", _drag)
+
+    def mouse_swipe_for_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        if self.simulator_device is None:
+            self.get_simulator()
+
+        if self.simulator_bluestacks:
+            end_x = max(1, min(x + dx, self.simulator_max_x - 1))
+            end_y = max(1, min(y + dy, self.simulator_max_y - 1))
+            plan = build_scroll_swipe_plan(
+                x, y, end_x - x, end_y - y, duration
+            )
+        else:
+            plan = [
+                (self._scale(*point), move_duration)
+                for point, move_duration in build_scroll_swipe_plan(
+                    x, y, dx, dy, duration
+                )
+            ]
+
+        def _swipe():
+            self.simulator_control._send_swipe_plan_in_one_batch(plan)
+
+        self._call_with_reconnect(
+            "快速滑动并立即抬起",
+            _swipe,
+        )
 
     def close_current_app(self):
         if self.simulator_device is None:

--- a/tasks/teams/team_formation.py
+++ b/tasks/teams/team_formation.py
@@ -73,18 +73,20 @@ def select_battle_team(num):
         auto.mouse_click(my_position[0], my_position[1])
         sleep(0.5)
         for _ in range(3):
-            auto.mouse_drag(my_position[0], my_position[1], dy=1333 * scale, drag_time=0.3)
+            auto.mouse_swipe_for_scroll(
+                my_position[0], my_position[1], dy=1333 * scale, duration=0.3
+            )
         sleep(0.75)
         first_position = [position[0], position[1] + 70 * scale]
         if cfg.select_team_by_order:
             team_range = (num - 1) // 5
             team_order = (num - 1) % 5
             for _ in range(team_range):
-                auto.mouse_drag(
+                auto.mouse_swipe_for_scroll(
                     first_position[0],
                     first_position[1] + 375 * scale,
                     dy=-375 * scale,
-                    drag_time=1.5,
+                    duration=0.3,
                 )
                 sleep(1)
             if num <= 15:
@@ -108,11 +110,11 @@ def select_battle_team(num):
                     auto.mouse_action_with_pos(team_position, offset=False)
                     find = True
                     break
-                auto.mouse_drag(
+                auto.mouse_swipe_for_scroll(
                     first_position[0],
                     first_position[1] + 375 * scale,
                     dy=-385 * scale,
-                    drag_time=1.5,
+                    duration=0.3,
                 )
                 sleep(1)
                 while auto.take_screenshot() is None:


### PR DESCRIPTION
## 改动内容

- 为列表滚动增加 `mouse_swipe_for_scroll` 输入接口
- 将快速脱离长按区域的路径与时间规划集中到独立模块，供不同输入后端统一使用
- Windows 前台、后台和 `window_move`、MuMu、通用模拟器及 minitouch 后端均补齐滚动滑动实现
- 编队选择列表改用滚动专用手势，避免长按触发队伍拖拽排序
- minitouch 的连续滑动在同一批指令中发送，并复用统一的坐标归一化逻辑

## 问题原因

编队列表原先复用普通拖拽手势。部分输入后端在按下后未能足够快地离开长按判定区域，或在终点存在额外停留，因此游戏会把滚动识别为队伍排序拖拽，导致队伍顺序意外改变。
