### PR TITLE
fix(back_init_menu): 避免加载期间误判卡死并重启游戏

### DIFF
--- a/tasks/base/back_init_menu.py
+++ b/tasks/base/back_init_menu.py
@@ -1,4 +1,4 @@
-from time import sleep
+from time import monotonic, sleep
 
 from module.automation import auto
 from module.decorator.decorator import begin_and_finish_time_log
@@ -8,10 +8,12 @@ from tasks.base.retry import click_title_screen_safely, ensure_simulator_game_st
 from tasks.mirror.reward_card import get_reward_card
 
 LOOP_COUNT=30
+LOADING_TIMEOUT = 90
 
 @begin_and_finish_time_log(task_name="返回主界面")
 def back_init_menu(*, allow_restart: bool = True):
     loop_count = LOOP_COUNT
+    loading_started_at = None
     auto.model = "clam"
     while True:
         loop_count -= 1
@@ -83,10 +85,12 @@ def back_init_menu(*, allow_restart: bool = True):
             continue
 
         # 等待加载情况
-        if auto.find_element("base/waiting_assets.png"):
+        if auto.find_element("base/waiting_assets.png") or auto.find_element("base/waiting_2_assets.png"):
+            if loading_started_at is None:
+                loading_started_at = monotonic()
+            loop_count = LOOP_COUNT if monotonic() - loading_started_at < LOADING_TIMEOUT else 0
             continue
-        if auto.find_element("base/waiting_2_assets.png"):
-            continue
+        loading_started_at = None
 
         # 左上角有后退键
         if auto.click_element("home/back_assets.png"):


### PR DESCRIPTION
## 问题原因

返回主界面时，游戏加载画面虽然已被识别，但当前逻辑仍在每轮循环开始时扣减 `loop_count`。加载时间较长时，常规重试次数会被耗尽，程序误判游戏卡死并重启，随后重复该流程。

## 改动内容

- 加载画面期间不再消耗返回主界面的常规重试次数
- 记录加载开始时间，加载未超过 90 秒时继续等待
- 加载超过 90 秒后沿用原有重启游戏流程
- 未识别到加载画面时保持原有 30 次重试逻辑