### PR TITLE
feat: 支持远程模拟器并改进任务稳定性

### DIFF
--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -904,6 +904,7 @@ class PushSettingCardChance(BasePushSettingCard):
         icon: Union[str, QIcon, FluentIconBase],
         title,
         config_name: str,
+        min_value=0,
         max_value=3,
         content=None,
         on_confirm: Callable[[int], None] | None = None,
@@ -911,6 +912,7 @@ class PushSettingCardChance(BasePushSettingCard):
     ):
         super().__init__(text, icon, title, content, parent)
         self.config_name = config_name
+        self.min_value = min_value
         self.max_value = max_value
         self.on_confirm = on_confirm
         self.line_text = LineEdit()
@@ -927,6 +929,7 @@ class PushSettingCardChance(BasePushSettingCard):
             self.tr(self.title),
             config_name=self.config_name,
             parent=self.window(),
+            min_value=self.min_value,
             max_value=self.max_value,
         )
         if message_box.exec():

--- a/app/base_combination.py
+++ b/app/base_combination.py
@@ -937,6 +937,47 @@ class PushSettingCardChance(BasePushSettingCard):
                 self.on_confirm(new_value)
 
 
+class PushSettingCardText(BasePushSettingCard):
+    def __init__(
+        self,
+        text,
+        icon: Union[str, QIcon, FluentIconBase],
+        title,
+        config_name: str,
+        content=None,
+        validator: Callable[[str], str] | None = None,
+        parent=None,
+    ):
+        super().__init__(text, icon, title, content, parent)
+        self.config_name = config_name
+        self.validator = validator
+        self.line_text = LineEdit()
+        self.line_text.setAlignment(Qt.AlignCenter)
+        self.line_text.setReadOnly(True)
+        self.line_text.setMaximumWidth(180)
+        self.line_text.setText(str(cfg.get_value(self.config_name)))
+        current_count = self.hBoxLayout.count()
+        self.hBoxLayout.insertWidget(current_count - 2, self.line_text)
+        self.button.clicked.connect(self.__onclicked)
+
+    def __onclicked(self):
+        current_value = str(cfg.get_value(self.config_name, ""))
+        message_box = MessageBoxEdit(self.tr(self.title), current_value, self.window())
+        if not message_box.exec():
+            return
+
+        new_value = message_box.getText().strip()
+        try:
+            if self.validator is not None:
+                new_value = self.validator(new_value)
+        except ValueError as exc:
+            MessageBox(self.tr("配置无效"), str(exc), self.window()).exec()
+            return
+
+        cfg.set_value(self.config_name, new_value)
+        self.line_text.setText(new_value)
+
+
 class AutoDailyView(FlyoutViewBase):
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/app/card/messagebox_custom.py
+++ b/app/card/messagebox_custom.py
@@ -432,7 +432,7 @@ class MessageBoxDate(MessageBox):
 
 
 class MessageBoxSpinbox(MessageBox):
-    def __init__(self, title: str, config_name: str, parent=None, max_value=3):
+    def __init__(self, title: str, config_name: str, parent=None, min_value=0, max_value=3):
         super().__init__(title, "", parent)
 
         self.text = title
@@ -446,7 +446,7 @@ class MessageBoxSpinbox(MessageBox):
         self.box = SpinBox(self)
         initial_value = cfg.get_value(config_name, 0)
         max_int = int(max_value)
-        self.box.setMinimum(0)
+        self.box.setMinimum(int(min_value))
         self.box.setMaximum(max_int)
         self.box.setValue(int(initial_value))
 

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -226,6 +226,19 @@ class SettingInterface(QWidget):
             content="",
             parent=self.simulator_setting_group,
         )
+        self.task_stall_timeout_chance_card = PushSettingCardChance(
+            QT_TRANSLATE_NOOP("PushSettingCardChance", "修改"),
+            FIF.TRAIN,
+            QT_TRANSLATE_NOOP("PushSettingCardChance", "任务卡死重启等待时间(秒)"),
+            config_name="task_stall_timeout",
+            min_value=30,
+            max_value=3600,
+            content=QT_TRANSLATE_NOOP(
+                "PushSettingCardChance",
+                "页面长时间无进展后才会重启游戏；低性能模拟器建议设置为600秒",
+            ),
+            parent=self.simulator_setting_group,
+        )
 
         self.game_path_group = BaseSettingCardGroup(
             QT_TRANSLATE_NOOP("BaseSettingCardGroup", "启动游戏"), self.scroll_widget
@@ -498,6 +511,7 @@ class SettingInterface(QWidget):
         self.simulator_setting_group.addSettingCard(self.simulator_host_setting_card)
         self.simulator_setting_group.addSettingCard(self.simulator_port_chance_card)
         self.simulator_setting_group.addSettingCard(self.start_emulator_timeout_chance_card)
+        self.simulator_setting_group.addSettingCard(self.task_stall_timeout_chance_card)
 
         self.game_path_group.addSettingCard(self.game_path_card)
         self.game_path_group.addSettingCard(self.autostart_card)
@@ -733,6 +747,7 @@ class SettingInterface(QWidget):
         self.simulator_host_setting_card.retranslateUi()
         self.simulator_port_chance_card.retranslateUi()
         self.start_emulator_timeout_chance_card.retranslateUi()
+        self.task_stall_timeout_chance_card.retranslateUi()
         self.game_path_card.retranslateUi()
         self.game_path_group.retranslateUi()
         self.autodaily_group.retranslateUi()

--- a/app/setting_interface.py
+++ b/app/setting_interface.py
@@ -31,6 +31,7 @@ from app.base_combination import (
     PushSettingCardChance,
     PushSettingCardDate,
     PushSettingCardMirrorchyan,
+    PushSettingCardText,
     SwitchSettingCard,
 )
 from app.card.messagebox_custom import BaseInfoBar
@@ -39,6 +40,7 @@ from app.language_manager import SUPPORTED_LANG_NAME, LanguageManager
 from app.theme_pack_setting_interface import ThemePackSettingDialog
 from app.widget.setting_nav import SettingNav
 from module.config import cfg, theme_list
+from utils.adb_endpoint import normalize_adb_host
 from utils.schedule_helper import ScheduleHelper
 
 
@@ -192,6 +194,18 @@ class SettingInterface(QWidget):
                 QT_TRANSLATE_NOOP("ComboBoxSettingCard", "MuMu模拟器(推荐)"): 0,
                 QT_TRANSLATE_NOOP("ComboBoxSettingCard", "其他模拟器"): 10,
             },
+            parent=self.simulator_setting_group,
+        )
+        self.simulator_host_setting_card = PushSettingCardText(
+            QT_TRANSLATE_NOOP("PushSettingCardText", "修改"),
+            FIF.CONNECT,
+            QT_TRANSLATE_NOOP("PushSettingCardText", "模拟器主机地址"),
+            config_name="simulator_host",
+            content=QT_TRANSLATE_NOOP(
+                "PushSettingCardText",
+                "其他模拟器的 ADB 主机名或 IP；远程连接时填写远程设备地址",
+            ),
+            validator=normalize_adb_host,
             parent=self.simulator_setting_group,
         )
         self.simulator_port_chance_card = PushSettingCardChance(
@@ -481,6 +495,7 @@ class SettingInterface(QWidget):
 
         self.simulator_setting_group.addSettingCard(self.simulator_setting_card)
         self.simulator_setting_group.addSettingCard(self.simulator_type_setting_card)
+        self.simulator_setting_group.addSettingCard(self.simulator_host_setting_card)
         self.simulator_setting_group.addSettingCard(self.simulator_port_chance_card)
         self.simulator_setting_group.addSettingCard(self.start_emulator_timeout_chance_card)
 
@@ -715,6 +730,7 @@ class SettingInterface(QWidget):
         self.simulator_setting_group.retranslateUi()
         self.simulator_setting_card.retranslateUi()
         self.simulator_type_setting_card.retranslateUi()
+        self.simulator_host_setting_card.retranslateUi()
         self.simulator_port_chance_card.retranslateUi()
         self.start_emulator_timeout_chance_card.retranslateUi()
         self.game_path_card.retranslateUi()

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -65,7 +65,8 @@ experimental_hdr_warning: True # 任务启动时检测游戏显示器 HDR 状态
 # 模拟器设置
 simulator: False # 是否使用模拟器
 simulator_type: 0 # 0:mumu , 10:其他 。TODO:蓝迭 , 雷电 , 夜神 , 逍遥
-simulator_port: 0 # 端口
+simulator_host: 127.0.0.1 # 其他模拟器的ADB主机名或IP；远程连接时填写远程设备地址
+simulator_port: 0 # 其他模拟器的ADB端口
 mumu_instance_number: -1 # mumu模拟器的实例编号
 start_emulator_timeout: 120 # 启动模拟器超时时间
 adb_reconnect_on_error: True # ADB或minitouch连接失效时自动重连

--- a/assets/config/config.example.yaml
+++ b/assets/config/config.example.yaml
@@ -69,6 +69,7 @@ simulator_host: 127.0.0.1 # 其他模拟器的ADB主机名或IP；远程连接�
 simulator_port: 0 # 其他模拟器的ADB端口
 mumu_instance_number: -1 # mumu模拟器的实例编号
 start_emulator_timeout: 120 # 启动模拟器超时时间
+task_stall_timeout: 600 # 页面长时间无进展后重启游戏的等待时间（秒）
 adb_reconnect_on_error: True # ADB或minitouch连接失效时自动重连
 
 # 自动更新

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -2446,6 +2446,29 @@ These fields will be populated with default values. Do you wish to continue?</tr
     </message>
 </context>
 <context>
+    <name>PushSettingCardText</name>
+    <message>
+        <location filename="../app/setting_interface.py" line="200"/>
+        <source>修改</source>
+        <translation>Edit</translation>
+    </message>
+    <message>
+        <location filename="../app/setting_interface.py" line="202"/>
+        <source>模拟器主机地址</source>
+        <translation>Emulator Host</translation>
+    </message>
+    <message>
+        <location filename="../app/setting_interface.py" line="206"/>
+        <source>其他模拟器的 ADB 主机名或 IP；远程连接时填写远程设备地址</source>
+        <translation>ADB hostname or IP for other emulators; enter the remote device address for remote connections</translation>
+    </message>
+    <message>
+        <location filename="../app/base_combination.py" line="977"/>
+        <source>配置无效</source>
+        <translation>Invalid Configuration</translation>
+    </message>
+</context>
+<context>
     <name>PushSettingCardDate</name>
     <message>
         <location filename="../app/setting_interface.py" line="136"/>

--- a/i18n/myapp_en.ts
+++ b/i18n/myapp_en.ts
@@ -2426,6 +2426,7 @@ These fields will be populated with default values. Do you wish to continue?</tr
         <location filename="../app/setting_interface.py" line="142"/>
         <location filename="../app/setting_interface.py" line="198"/>
         <location filename="../app/setting_interface.py" line="207"/>
+        <location filename="../app/setting_interface.py" line="230"/>
         <source>修改</source>
         <translation>Edit</translation>
     </message>
@@ -2443,6 +2444,16 @@ These fields will be populated with default values. Do you wish to continue?</tr
         <location filename="../app/setting_interface.py" line="209"/>
         <source>仅限MUMU模拟器——启动模拟器超时时间(秒)</source>
         <translation>Start Simulator Timeout</translation>
+    </message>
+    <message>
+        <location filename="../app/setting_interface.py" line="232"/>
+        <source>任务卡死重启等待时间(秒)</source>
+        <translation>Task Stall Restart Timeout (seconds)</translation>
+    </message>
+    <message>
+        <location filename="../app/setting_interface.py" line="238"/>
+        <source>页面长时间无进展后才会重启游戏；低性能模拟器建议设置为600秒</source>
+        <translation>Restart the game only after a page remains stalled; 600 seconds is recommended for slower emulators</translation>
     </message>
 </context>
 <context>

--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -40,6 +40,7 @@ class Automation(metaclass=SingletonMeta):
         self.screenshot = None
         self.input_handler = AbstractInput()
         self._screenshot_lock = threading.RLock()
+        self._input_lock = threading.RLock()
         self._interaction_gate = threading.Event()
         self._interaction_gate.set()
 
@@ -88,17 +89,8 @@ class Automation(metaclass=SingletonMeta):
 
             self.input_handler = BackgroundInput()
         assert isinstance(self.input_handler, AbstractInput), "输入处理器必须是AbstractInput的实例"
-        self.mouse_click_blank = self.input_handler.mouse_click_blank
-        self.mouse_drag = self.input_handler.mouse_drag
-        self.mouse_swipe_for_scroll = self.input_handler.mouse_swipe_for_scroll
-        self.mouse_drag_down = self.input_handler.mouse_drag_down
-        self.mouse_scroll = self.input_handler.mouse_scroll
         self.set_pause = self.input_handler.set_pause
         self.wait_pause = self.input_handler.wait_pause
-        self.mouse_to_blank = self.input_handler.mouse_to_blank
-        self.mouse_drag_link = self.input_handler.mouse_drag_link
-        self.key_press = self.input_handler.key_press
-        self.input_text = self.input_handler.input_text
         self.memory_protection = cfg.memory_protection
 
     def suspend_interactions(self) -> None:
@@ -109,14 +101,53 @@ class Automation(metaclass=SingletonMeta):
         """恢复业务线程点击。"""
         self._interaction_gate.set()
 
+    def _run_business_interaction(self, method_name: str, *args, **kwargs):
+        """在交互门放行且取得输入锁后执行一次业务输入。
+
+        交互门可能在等待输入锁期间被监控线程关闭，因此取得锁后需要再次确认。
+        """
+        while True:
+            self._interaction_gate.wait()
+            with self._input_lock:
+                if not self._interaction_gate.is_set():
+                    continue
+                method = getattr(self.input_handler, method_name)
+                return method(*args, **kwargs)
+
     def mouse_click(self, x, y, times=1):
-        """执行受监控线程互斥保护的业务点击。"""
-        self._interaction_gate.wait()
-        return self.input_handler.mouse_click(x, y, times=times)
+        return self._run_business_interaction("mouse_click", x, y, times=times)
+
+    def mouse_click_blank(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_click_blank", *args, **kwargs)
+
+    def mouse_drag(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_drag", *args, **kwargs)
+
+    def mouse_swipe_for_scroll(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_swipe_for_scroll", *args, **kwargs)
+
+    def mouse_drag_down(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_drag_down", *args, **kwargs)
+
+    def mouse_scroll(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_scroll", *args, **kwargs)
+
+    def mouse_to_blank(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_to_blank", *args, **kwargs)
+
+    def mouse_drag_link(self, *args, **kwargs):
+        return self._run_business_interaction("mouse_drag_link", *args, **kwargs)
+
+    def key_press(self, *args, **kwargs):
+        return self._run_business_interaction("key_press", *args, **kwargs)
+
+    def input_text(self, *args, **kwargs):
+        return self._run_business_interaction("input_text", *args, **kwargs)
 
     def monitor_mouse_click(self, x, y, times=1):
         """由系统监控线程点击，不等待该监控线程设置的互斥门。"""
-        return self.input_handler.mouse_click(x, y, times=times)
+        with self._input_lock:
+            return self.input_handler.mouse_click(x, y, times=times)
 
     def take_monitor_screenshot(self, gray: bool = True) -> Image | None:
         """获取监控截图，不覆盖业务线程当前使用的截图。"""

--- a/module/automation/automation.py
+++ b/module/automation/automation.py
@@ -1,6 +1,7 @@
 import gc
 import math
 import random
+import threading
 import time
 from ast import List
 from dataclasses import dataclass
@@ -38,6 +39,9 @@ class Automation(metaclass=SingletonMeta):
         self.windows_title = windows_title
         self.screenshot = None
         self.input_handler = AbstractInput()
+        self._screenshot_lock = threading.RLock()
+        self._interaction_gate = threading.Event()
+        self._interaction_gate.set()
 
         self.init_input()
 
@@ -84,7 +88,6 @@ class Automation(metaclass=SingletonMeta):
 
             self.input_handler = BackgroundInput()
         assert isinstance(self.input_handler, AbstractInput), "输入处理器必须是AbstractInput的实例"
-        self.mouse_click = self.input_handler.mouse_click
         self.mouse_click_blank = self.input_handler.mouse_click_blank
         self.mouse_drag = self.input_handler.mouse_drag
         self.mouse_swipe_for_scroll = self.input_handler.mouse_swipe_for_scroll
@@ -97,6 +100,28 @@ class Automation(metaclass=SingletonMeta):
         self.key_press = self.input_handler.key_press
         self.input_text = self.input_handler.input_text
         self.memory_protection = cfg.memory_protection
+
+    def suspend_interactions(self) -> None:
+        """暂时阻止业务线程继续点击。"""
+        self._interaction_gate.clear()
+
+    def resume_interactions(self) -> None:
+        """恢复业务线程点击。"""
+        self._interaction_gate.set()
+
+    def mouse_click(self, x, y, times=1):
+        """执行受监控线程互斥保护的业务点击。"""
+        self._interaction_gate.wait()
+        return self.input_handler.mouse_click(x, y, times=times)
+
+    def monitor_mouse_click(self, x, y, times=1):
+        """由系统监控线程点击，不等待该监控线程设置的互斥门。"""
+        return self.input_handler.mouse_click(x, y, times=times)
+
+    def take_monitor_screenshot(self, gray: bool = True) -> Image | None:
+        """获取监控截图，不覆盖业务线程当前使用的截图。"""
+        with self._screenshot_lock:
+            return ScreenShot.take_screenshot(gray)
 
     def check_pause(self) -> bool:
         """
@@ -225,6 +250,7 @@ class Automation(metaclass=SingletonMeta):
             self.last_click_time = time.time()
 
         # 计算传入的位置
+        self._interaction_gate.wait()
         x, y = self.calculate_click_position(coordinates, offset)
 
         # 定义鼠标操作映射
@@ -270,7 +296,8 @@ class Automation(metaclass=SingletonMeta):
                     )
                     time.sleep(wait_time)
 
-                result = ScreenShot.take_screenshot(gray)
+                with self._screenshot_lock:
+                    result = ScreenShot.take_screenshot(gray)
                 if result:
                     self.screenshot = result
                     self.last_screenshot_time = time.time()

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 import time
 from functools import partial
 from time import sleep
@@ -232,6 +233,7 @@ class MumuControl(AbstractInput):
 
         self.lib = None
         self._ev = asyncio.new_event_loop()
+        self._ev_lock = threading.RLock()
         self.display_id = display_id
 
         self.connect_id: int = 0
@@ -775,22 +777,25 @@ class MumuControl(AbstractInput):
             NemuIpcIncompatible:
             NemuIpcError
         """
-        result = self._ev.run_until_complete(self.ev_run_async(func, *args, **kwargs))
+        # MuMu 截图和输入共用同一个 asyncio 事件循环。重试监控会从后台线程截图，
+        # 因此必须在最底层串行化所有 NemuIpc 调用，避免并发 run_until_complete。
+        with self._ev_lock:
+            result = self._ev.run_until_complete(self.ev_run_async(func, *args, **kwargs))
 
-        err = False
-        if func.__name__ == "nemu_connect":
-            if result == 0:
-                err = True
-        else:
-            if result > 0:
-                err = True
-        # Get to actual error message printed in std
-        if err:
-            log.warning(f"调用 {func.__name__} 失败，结果={result}")
-            with CaptureNemuIpc(log):
-                result = self._ev.run_until_complete(self.ev_run_async(func, *args, **kwargs))
+            err = False
+            if func.__name__ == "nemu_connect":
+                if result == 0:
+                    err = True
+            else:
+                if result > 0:
+                    err = True
+            # Get to actual error message printed in std
+            if err:
+                log.warning(f"调用 {func.__name__} 失败，结果={result}")
+                with CaptureNemuIpc(log):
+                    result = self._ev.run_until_complete(self.ev_run_async(func, *args, **kwargs))
 
-        return result
+            return result
 
     def get_resolution(self):
         """

--- a/module/automation/input_handlers/simulator/simulator_control.py
+++ b/module/automation/input_handlers/simulator/simulator_control.py
@@ -10,12 +10,14 @@ from adbutils.errors import AdbError
 
 from module.config import cfg
 from module.logger import log
+from utils.adb_endpoint import build_adb_endpoint
 
 from .. import AbstractInput
 from ..scroll_swipe import build_scroll_swipe_plan
 from .pyminitouch import MNTDevice
 
 T = TypeVar("T")
+ADB_CONNECT_TIMEOUT = 10.0
 
 key_list = {
     "a": 29,
@@ -170,36 +172,36 @@ class SimulatorControl(AbstractInput):
             self._call_with_reconnect("启动游戏", _start_game)
 
     def adb_connect(self):
-        # Try to connect
-        port = int(cfg.simulator_port)
-        if port <= 0:
-            raise RuntimeError("其他模拟器需要填写 ADB 端口，例如蓝叠/雷电常见为 5555")
-        for _ in range(3):
-            self.simulator_port = f"127.0.0.1:{port}"
-            msg = adb.connect(self.simulator_port)
+        """连接设置中指定的本地或远程 ADB TCP 设备。"""
+        self.simulator_port = build_adb_endpoint(cfg.simulator_host, cfg.simulator_port)
+        last_message = ""
+        for attempt in range(3):
+            msg = adb.connect(self.simulator_port, timeout=ADB_CONNECT_TIMEOUT)
+            last_message = str(msg)
             # Connected to 127.0.0.1:59865
             # Already connected to 127.0.0.1:59865
-            if "connected" in msg:
+            if "connected" in last_message.lower():
                 log.debug(f"成功连接至:{self.simulator_port},连接信息: {msg}")
-                break
-            # bad port number '598265' in '127.0.0.1:598265'
-            elif "bad port" in msg:
-                log.error(f"连接失败，端口号{self.simulator_port}不正确，可能是拼写错误或不规范")
+                return
+            log.warning(
+                f"连接模拟器失败 ({attempt + 1}/3): endpoint={self.simulator_port}, response={last_message}"
+            )
+            sleep(1)
+        raise RuntimeError(f"无法通过 ADB 连接模拟器 {self.simulator_port}: {last_message or 'ADB 未返回原因'}")
 
     def adb_disconnect(self):
+        if self.simulator_port is None:
+            return
         try:
             for _ in range(3):
                 msg = adb.disconnect(self.simulator_port)
                 # Connected to 127.0.0.1:59865
                 # Already connected to 127.0.0.1:59865
-                if "disconnected" in msg:
+                if "disconnected" in msg.lower():
                     log.debug(f"成功断开连接于:{self.simulator_port},连接信息: {msg}")
                     break
-                # bad port number '598265' in '127.0.0.1:598265'
-                elif "bad port" in msg:
-                    log.error(f"断开连接失败，端口号{self.simulator_port}不正确，可能是拼写错误或不规范")
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(f"断开模拟器 ADB 连接失败: endpoint={self.simulator_port}, error={exc}")
 
     def get_simulator(self):
         if self.simulator_device is not None:

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -355,6 +355,9 @@ class ConfigModel(BaseModel):
     start_emulator_timeout: int
     """启动模拟器超时时间"""
 
+    task_stall_timeout: int
+    """页面长时间无进展后重启游戏的等待时间（秒）"""
+
     adb_reconnect_on_error: bool
     """ADB或minitouch连接失效时自动重连"""
 

--- a/module/config/config_typing.py
+++ b/module/config/config_typing.py
@@ -343,8 +343,11 @@ class ConfigModel(BaseModel):
     simulator_type: int
     """0:mumu, 10:其他"""
 
+    simulator_host: str
+    """其他模拟器的 ADB 主机名或 IP 地址"""
+
     simulator_port: int
-    """端口"""
+    """其他模拟器的 ADB 端口"""
 
     mumu_instance_number: int
     """mumu模拟器的实例编号"""

--- a/tasks/base/retry.py
+++ b/tasks/base/retry.py
@@ -14,6 +14,8 @@ from utils.utils import check_game_running
 
 _last_title_screen_tap_time = 0.0
 _last_simulator_alive_check_time = 0.0
+DEFAULT_TASK_STALL_TIMEOUT = 600
+MIN_TASK_STALL_TIMEOUT = 30
 
 
 def ensure_simulator_game_started() -> bool:
@@ -116,11 +118,23 @@ def kill_game():
         sleep(1)
 
 
-def check_times(start_time, timeout=90, logs=True):
+def get_task_stall_timeout() -> int:
+    """读取页面卡死等待时间，并为异常配置提供安全下限。"""
+    configured_timeout = int(cfg.get_value("task_stall_timeout", DEFAULT_TASK_STALL_TIMEOUT))
+    return max(MIN_TASK_STALL_TIMEOUT, configured_timeout)
+
+
+def check_times(start_time, timeout=None, logs=True):
     """检查是否卡死超时，若是则尝试关闭重启游戏"""
+    if timeout is None:
+        timeout = get_task_stall_timeout()
     now_time = time.time()
     if logs and int(now_time - start_time) > 9 and int(now_time - start_time) % 10 == 0:
-        log.info(f"初始时间为{time.strftime('%H:%M:%S', time.localtime(start_time))}，此刻时间为{time.strftime('%H:%M:%S', time.localtime(now_time))}，已卡死{int(now_time - start_time)}秒")
+        log.info(
+            f"初始时间为{time.strftime('%H:%M:%S', time.localtime(start_time))}，"
+            f"此刻时间为{time.strftime('%H:%M:%S', time.localtime(now_time))}，"
+            f"已卡死{int(now_time - start_time)}秒"
+        )
         sleep(1)
     if now_time - start_time > timeout:
         log.info(f"已卡死超过{timeout}秒，尝试关闭重启游戏")

--- a/tasks/base/retry_monitor.py
+++ b/tasks/base/retry_monitor.py
@@ -1,0 +1,139 @@
+import threading
+import time
+
+import cv2
+import numpy as np
+
+from module.automation import auto
+from module.logger import log
+from utils.image_utils import ImageUtils
+
+
+class RetryMonitor:
+    """独立处理服务器重试弹窗，避免业务流程各自重复实现。"""
+
+    RETRY_TEMPLATE = "base/retry.png"
+    TEMPLATE_PATHS = ("default/en", "default/zh_cn")
+
+    def __init__(self, poll_interval: float = 0.5, click_cooldown: float = 2.0):
+        self.poll_interval = poll_interval
+        self.click_cooldown = click_cooldown
+        self._stop_event = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._templates: tuple[np.ndarray, ...] = ()
+        self._last_click_time = 0.0
+        self._handling_retry = False
+        self._clear_frames = 0
+
+    def start(self) -> None:
+        """加载模板并启动监控线程；重复调用不会创建多个线程。"""
+        with self._lifecycle_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._templates = self._load_templates()
+            if not self._templates:
+                log.warning("未能加载通用重试按钮模板，重试监控线程未启动")
+                return
+            self._last_click_time = 0.0
+            self._handling_retry = False
+            self._clear_frames = 0
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._run,
+                name="ServerRetryMonitor",
+                daemon=True,
+            )
+            self._thread.start()
+            log.debug("通用服务器重试监控线程已启动")
+
+    def stop(self) -> None:
+        """停止监控并确保业务点击门恢复。"""
+        with self._lifecycle_lock:
+            thread = self._thread
+            self._thread = None
+            self._stop_event.set()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=2)
+        self._handling_retry = False
+        self._clear_frames = 0
+        auto.resume_interactions()
+        if thread is not None:
+            log.debug("通用服务器重试监控线程已停止")
+
+    def _load_templates(self) -> tuple[np.ndarray, ...]:
+        templates = []
+        for path in self.TEMPLATE_PATHS:
+            template = ImageUtils.load_from_specific_path(self.RETRY_TEMPLATE, path)
+            if template is not None:
+                templates.append(template)
+        return tuple(templates)
+
+    @staticmethod
+    def _to_gray_array(screenshot) -> np.ndarray:
+        image = np.asarray(screenshot)
+        if image.ndim == 3:
+            image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+        return image
+
+    def _find_retry_button(self, screenshot) -> tuple[int, int] | None:
+        image = self._to_gray_array(screenshot)
+        best_center = None
+        best_score = 0.9
+        for template in self._templates:
+            match = ImageUtils.match_template(image, template, None, model="clam")
+            if match is None:
+                continue
+            center, score = match
+            if score >= best_score:
+                best_center = center
+                best_score = score
+        return best_center
+
+    def check_once(self, screenshot=None) -> bool:
+        """检查一次重试弹窗，返回本轮是否执行了点击。"""
+        if screenshot is None:
+            screenshot = auto.take_monitor_screenshot()
+        if screenshot is None:
+            return False
+        if auto.check_pause() and not self._handling_retry:
+            return False
+
+        retry_position = self._find_retry_button(screenshot)
+        if retry_position is None:
+            if self._handling_retry:
+                self._clear_frames += 1
+                if self._clear_frames >= 2:
+                    self._handling_retry = False
+                    self._clear_frames = 0
+                    auto.resume_interactions()
+                    log.debug("服务器错误弹窗已消失，恢复业务点击")
+            return False
+
+        self._clear_frames = 0
+        if not self._handling_retry:
+            self._handling_retry = True
+            auto.suspend_interactions()
+            log.debug("服务器错误弹窗处理中，暂时阻止业务点击")
+
+        if auto.check_pause():
+            return False
+
+        now = time.monotonic()
+        if now - self._last_click_time < self.click_cooldown:
+            return False
+
+        auto.monitor_mouse_click(retry_position[0], retry_position[1])
+        self._last_click_time = now
+        log.warning(f"检测到服务器错误弹窗，监控线程已点击重试: {retry_position}")
+        return True
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self.poll_interval):
+            try:
+                self.check_once()
+            except Exception:
+                log.exception("通用服务器重试监控线程处理异常")
+
+
+retry_monitor = RetryMonitor()

--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -39,6 +39,7 @@ from tasks.base.make_enkephalin_module import (
     lunacy_to_enkephalin,
     make_enkephalin_module,
 )
+from tasks.base.retry_monitor import retry_monitor
 from tasks.battle import battle
 from tasks.daily.get_prize import get_mail_prize, get_pass_prize
 from tasks.daily.luxcavation import EXP_luxcavation, thread_luxcavation
@@ -372,6 +373,7 @@ def script_task() -> None | int:
     path_manager.initialize_paths()
     auto.clear_img_cache()
     log.debug(f"初始化图片路径: {path_manager.pic_path}")
+    retry_monitor.start()
 
     if cfg.resonate_with_Ahab:
         Resonate_with_Ahab()
@@ -472,9 +474,14 @@ class my_script_task(QThread):
             self.exception = e
             log.exception("脚本线程执行失败")
         finally:
+            retry_monitor.stop()
             self.mutex.unlock()
 
         mediator.script_finished.emit()
+
+    def terminate(self):
+        retry_monitor.stop()
+        super().terminate()
 
     """def stop(self):
         self.running=False

--- a/tests/unit/module/automation/test_interaction_gate.py
+++ b/tests/unit/module/automation/test_interaction_gate.py
@@ -8,6 +8,7 @@ def test_mouse_click_waits_until_monitor_resumes_interactions() -> None:
     clicks = []
     automation = object.__new__(Automation)
     automation._interaction_gate = threading.Event()
+    automation._input_lock = threading.RLock()
     automation.input_handler = SimpleNamespace(
         mouse_click=lambda x, y, times=1: clicks.append((x, y, times)) or True,
     )
@@ -28,3 +29,91 @@ def test_mouse_click_waits_until_monitor_resumes_interactions() -> None:
 
     assert not click_thread.is_alive()
     assert clicks == [(801, 583, 1)]
+
+
+def test_blank_click_uses_the_same_interaction_gate() -> None:
+    clicks = []
+    automation = object.__new__(Automation)
+    automation._interaction_gate = threading.Event()
+    automation._input_lock = threading.RLock()
+    automation.input_handler = SimpleNamespace(
+        mouse_click_blank=lambda: clicks.append("blank") or True,
+    )
+
+    click_thread = threading.Thread(target=automation.mouse_click_blank)
+    click_thread.start()
+
+    click_thread.join(timeout=0.1)
+    assert click_thread.is_alive()
+    assert clicks == []
+
+    automation.resume_interactions()
+    click_thread.join(timeout=1)
+
+    assert not click_thread.is_alive()
+    assert clicks == ["blank"]
+
+
+def test_monitor_and_business_inputs_cannot_enter_handler_concurrently() -> None:
+    monitor_entered = threading.Event()
+    release_monitor = threading.Event()
+    business_entered = threading.Event()
+    automation = object.__new__(Automation)
+    automation._interaction_gate = threading.Event()
+    automation._interaction_gate.set()
+    automation._input_lock = threading.RLock()
+
+    def monitor_click(_x, _y, times=1):
+        monitor_entered.set()
+        assert release_monitor.wait(timeout=1)
+        return True
+
+    def blank_click():
+        business_entered.set()
+        return True
+
+    automation.input_handler = SimpleNamespace(
+        mouse_click=monitor_click,
+        mouse_click_blank=blank_click,
+    )
+
+    monitor_thread = threading.Thread(target=lambda: automation.monitor_mouse_click(927, 583))
+    monitor_thread.start()
+    assert monitor_entered.wait(timeout=1)
+
+    business_thread = threading.Thread(target=automation.mouse_click_blank)
+    business_thread.start()
+    assert not business_entered.wait(timeout=0.1)
+
+    release_monitor.set()
+    monitor_thread.join(timeout=1)
+    business_thread.join(timeout=1)
+
+    assert not monitor_thread.is_alive()
+    assert not business_thread.is_alive()
+    assert business_entered.is_set()
+
+
+def test_business_input_rechecks_gate_after_waiting_for_input_lock() -> None:
+    business_entered = threading.Event()
+    automation = object.__new__(Automation)
+    automation._interaction_gate = threading.Event()
+    automation._interaction_gate.set()
+    automation._input_lock = threading.RLock()
+    automation.input_handler = SimpleNamespace(
+        mouse_click_blank=lambda: business_entered.set() or True,
+    )
+
+    automation._input_lock.acquire()
+    business_thread = threading.Thread(target=automation.mouse_click_blank)
+    business_thread.start()
+    automation.suspend_interactions()
+    automation._input_lock.release()
+
+    assert not business_entered.wait(timeout=0.1)
+
+    automation.resume_interactions()
+    business_thread.join(timeout=1)
+
+    assert not business_thread.is_alive()
+    assert business_entered.is_set()

--- a/tests/unit/module/automation/test_interaction_gate.py
+++ b/tests/unit/module/automation/test_interaction_gate.py
@@ -1,0 +1,30 @@
+import threading
+from types import SimpleNamespace
+
+from module.automation.automation import Automation
+
+
+def test_mouse_click_waits_until_monitor_resumes_interactions() -> None:
+    clicks = []
+    automation = object.__new__(Automation)
+    automation._interaction_gate = threading.Event()
+    automation.input_handler = SimpleNamespace(
+        mouse_click=lambda x, y, times=1: clicks.append((x, y, times)) or True,
+    )
+
+    started = threading.Event()
+
+    def click() -> None:
+        started.set()
+        automation.mouse_click(801, 583)
+
+    click_thread = threading.Thread(target=click)
+    click_thread.start()
+    assert started.wait(timeout=1)
+    assert clicks == []
+
+    automation.resume_interactions()
+    click_thread.join(timeout=1)
+
+    assert not click_thread.is_alive()
+    assert clicks == [(801, 583, 1)]

--- a/tests/unit/module/automation/test_mumu_event_loop.py
+++ b/tests/unit/module/automation/test_mumu_event_loop.py
@@ -1,0 +1,53 @@
+import asyncio
+import threading
+
+from module.automation.input_handlers.simulator.mumu_control import MumuControl
+
+
+def test_nemu_ipc_calls_are_serialized_across_threads() -> None:
+    control = object.__new__(MumuControl)
+    control._ev = asyncio.new_event_loop()
+    control._ev_lock = threading.RLock()
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    errors: list[Exception] = []
+
+    def first_call() -> int:
+        first_entered.set()
+        assert release_first.wait(timeout=1)
+        return 0
+
+    def second_call() -> int:
+        second_entered.set()
+        return 0
+
+    def run_call(func) -> None:
+        try:
+            control.ev_run_sync(func)
+        except Exception as exc:
+            errors.append(exc)
+
+    first_thread = threading.Thread(target=run_call, args=(first_call,))
+    second_thread = threading.Thread(target=run_call, args=(second_call,))
+
+    try:
+        first_thread.start()
+        assert first_entered.wait(timeout=1)
+
+        second_thread.start()
+        assert not second_entered.wait(timeout=0.1)
+
+        release_first.set()
+        first_thread.join(timeout=1)
+        second_thread.join(timeout=1)
+
+        assert not first_thread.is_alive()
+        assert not second_thread.is_alive()
+        assert second_entered.is_set()
+        assert errors == []
+    finally:
+        release_first.set()
+        first_thread.join(timeout=1)
+        second_thread.join(timeout=1)
+        control._ev.close()

--- a/tests/unit/module/automation/test_simulator_endpoint.py
+++ b/tests/unit/module/automation/test_simulator_endpoint.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+
+import pytest
+
+from module.automation.input_handlers.simulator import simulator_control
+from utils.adb_endpoint import (
+    build_adb_endpoint,
+    normalize_adb_host,
+)
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        (" emulator.example.com ", "emulator.example.com"),
+        ("[2001:db8::1]", "2001:db8::1"),
+    ],
+)
+def test_normalize_adb_host(host: str, expected: str) -> None:
+    assert normalize_adb_host(host) == expected
+
+
+@pytest.mark.parametrize("host", ["", "http://10.0.0.2", "host:5555", "bad host"])
+def test_normalize_adb_host_rejects_invalid_values(host: str) -> None:
+    with pytest.raises(ValueError):
+        normalize_adb_host(host)
+
+
+def test_build_adb_endpoint_for_remote_ipv4() -> None:
+    assert build_adb_endpoint("10.0.0.25", 5555) == "10.0.0.25:5555"
+
+
+def test_build_adb_endpoint_for_ipv6() -> None:
+    assert build_adb_endpoint("2001:db8::1", 5555) == "[2001:db8::1]:5555"
+
+
+@pytest.mark.parametrize("port", [0, 65536, "invalid"])
+def test_build_adb_endpoint_rejects_invalid_port(port) -> None:
+    with pytest.raises(ValueError):
+        build_adb_endpoint("127.0.0.1", port)
+
+
+def test_simulator_control_connects_to_configured_remote_endpoint(monkeypatch) -> None:
+    endpoints = []
+    fake_adb = SimpleNamespace(
+        connect=lambda endpoint, timeout: endpoints.append((endpoint, timeout)) or f"connected to {endpoint}"
+    )
+    fake_cfg = SimpleNamespace(simulator_host="10.0.0.25", simulator_port=5555)
+    monkeypatch.setattr(simulator_control, "adb", fake_adb)
+    monkeypatch.setattr(simulator_control, "cfg", fake_cfg)
+
+    control = simulator_control.SimulatorControl.__new__(simulator_control.SimulatorControl)
+    control.simulator_port = None
+    control.adb_connect()
+
+    assert endpoints == [("10.0.0.25:5555", simulator_control.ADB_CONNECT_TIMEOUT)]
+    assert control.simulator_port == "10.0.0.25:5555"
+
+
+def test_simulator_control_reports_remote_connection_failure(monkeypatch) -> None:
+    fake_adb = SimpleNamespace(connect=lambda endpoint, timeout: f"unable to connect to {endpoint}")
+    fake_cfg = SimpleNamespace(simulator_host="remote.example.com", simulator_port=5555)
+    monkeypatch.setattr(simulator_control, "adb", fake_adb)
+    monkeypatch.setattr(simulator_control, "cfg", fake_cfg)
+    monkeypatch.setattr(simulator_control, "sleep", lambda _seconds: None)
+
+    control = simulator_control.SimulatorControl.__new__(simulator_control.SimulatorControl)
+    control.simulator_port = None
+
+    with pytest.raises(RuntimeError, match=r"remote\.example\.com:5555"):
+        control.adb_connect()

--- a/tests/unit/tasks/base/test_retry_monitor.py
+++ b/tests/unit/tasks/base/test_retry_monitor.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from tasks.base import retry_monitor
+
+
+def test_check_once_clicks_strict_retry_match(monkeypatch) -> None:
+    screenshot = object()
+    clicks = []
+    gates = []
+    fake_auto = SimpleNamespace(
+        check_pause=lambda: False,
+        monitor_mouse_click=lambda x, y: clicks.append((x, y)),
+        suspend_interactions=lambda: gates.append("suspend"),
+        resume_interactions=lambda: gates.append("resume"),
+    )
+    monitor = retry_monitor.RetryMonitor(click_cooldown=0)
+    monitor._templates = (np.zeros((2, 2), dtype=np.uint8),)
+
+    monkeypatch.setattr(retry_monitor, "auto", fake_auto)
+    monkeypatch.setattr(monitor, "_find_retry_button", lambda _screenshot: (927, 583))
+
+    assert monitor.check_once(screenshot) is True
+    assert clicks == [(927, 583)]
+    assert gates == ["suspend"]
+
+
+def test_check_once_does_not_click_while_task_is_paused(monkeypatch) -> None:
+    fake_auto = SimpleNamespace(
+        check_pause=lambda: True,
+        monitor_mouse_click=lambda *_args: (_ for _ in ()).throw(AssertionError("must not click")),
+        suspend_interactions=lambda: None,
+        resume_interactions=lambda: None,
+    )
+    monitor = retry_monitor.RetryMonitor(click_cooldown=0)
+
+    monkeypatch.setattr(retry_monitor, "auto", fake_auto)
+    monkeypatch.setattr(
+        monitor,
+        "_find_retry_button",
+        lambda _screenshot: (_ for _ in ()).throw(AssertionError("must not match while paused")),
+    )
+
+    assert monitor.check_once(object()) is False
+
+
+def test_check_once_resumes_business_after_two_clear_frames(monkeypatch) -> None:
+    gates = []
+    fake_auto = SimpleNamespace(
+        check_pause=lambda: False,
+        monitor_mouse_click=lambda _x, _y: None,
+        suspend_interactions=lambda: gates.append("suspend"),
+        resume_interactions=lambda: gates.append("resume"),
+    )
+    monitor = retry_monitor.RetryMonitor(click_cooldown=0)
+
+    monkeypatch.setattr(retry_monitor, "auto", fake_auto)
+    matches = iter(((927, 583), None, None))
+    monkeypatch.setattr(monitor, "_find_retry_button", lambda _screenshot: next(matches))
+
+    assert monitor.check_once(object()) is True
+    assert monitor.check_once(object()) is False
+    assert monitor.check_once(object()) is False
+    assert gates == ["suspend", "resume"]
+
+
+def test_stop_always_restores_business_interactions(monkeypatch) -> None:
+    gates = []
+    fake_auto = SimpleNamespace(resume_interactions=lambda: gates.append("resume"))
+    monitor = retry_monitor.RetryMonitor()
+    monitor._handling_retry = True
+
+    monkeypatch.setattr(retry_monitor, "auto", fake_auto)
+
+    monitor.stop()
+
+    assert monitor._handling_retry is False
+    assert gates == ["resume"]

--- a/tests/unit/tasks/base/test_retry_monitor_lifecycle.py
+++ b/tests/unit/tasks/base/test_retry_monitor_lifecycle.py
@@ -1,0 +1,15 @@
+from tasks.base import script_task_scheme
+
+
+def test_terminating_script_stops_retry_monitor(monkeypatch) -> None:
+    monitor_stops = []
+    monkeypatch.setattr(
+        script_task_scheme.retry_monitor,
+        "stop",
+        lambda: monitor_stops.append(True),
+    )
+    task = script_task_scheme.my_script_task()
+
+    task.terminate()
+
+    assert monitor_stops == [True]

--- a/tests/unit/tasks/base/test_retry_timeout.py
+++ b/tests/unit/tasks/base/test_retry_timeout.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from tasks.base import retry
+
+
+def test_task_stall_timeout_uses_configured_value(monkeypatch) -> None:
+    monkeypatch.setattr(
+        retry,
+        "cfg",
+        SimpleNamespace(get_value=lambda key, default: 720),
+    )
+
+    assert retry.get_task_stall_timeout() == 720
+
+
+def test_task_stall_timeout_enforces_safe_minimum(monkeypatch) -> None:
+    monkeypatch.setattr(
+        retry,
+        "cfg",
+        SimpleNamespace(get_value=lambda key, default: 0),
+    )
+
+    assert retry.get_task_stall_timeout() == retry.MIN_TASK_STALL_TIMEOUT
+
+
+def test_check_times_uses_configured_timeout_by_default(monkeypatch) -> None:
+    start_time = 1_700_000_000.0
+    actions: list[str] = []
+    monkeypatch.setattr(retry, "get_task_stall_timeout", lambda: 600)
+    monkeypatch.setattr(retry.time, "time", lambda: start_time + 599)
+    monkeypatch.setattr(retry, "kill_game", lambda: actions.append("kill"))
+    monkeypatch.setattr(retry, "restart_game", lambda: actions.append("restart"))
+
+    assert retry.check_times(start_time, logs=False) is False
+    assert actions == []
+
+    monkeypatch.setattr(retry.time, "time", lambda: start_time + 601)
+
+    assert retry.check_times(start_time, logs=False) is True
+    assert actions == ["kill", "restart"]
+
+
+def test_check_times_preserves_explicit_flow_timeout(monkeypatch) -> None:
+    start_time = 1_700_000_000.0
+    actions: list[str] = []
+    monkeypatch.setattr(retry, "get_task_stall_timeout", lambda: 600)
+    monkeypatch.setattr(retry.time, "time", lambda: start_time + 901)
+    monkeypatch.setattr(retry, "kill_game", lambda: actions.append("kill"))
+    monkeypatch.setattr(retry, "restart_game", lambda: actions.append("restart"))
+
+    assert retry.check_times(start_time, timeout=1_200, logs=False) is False
+    assert actions == []

--- a/utils/adb_endpoint.py
+++ b/utils/adb_endpoint.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+
+_HOSTNAME_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+
+
+def normalize_adb_host(value: str) -> str:
+    """校验并规范化 ADB 目标主机名或 IP 地址。"""
+    host = str(value).strip()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1].strip()
+
+    if not host:
+        raise ValueError("模拟器主机地址不能为空")
+    if "://" in host or any(char in host for char in ("/", "\\", "?", "#")):
+        raise ValueError("请只填写主机名或 IP 地址，不要包含协议、路径或端口")
+
+    try:
+        return ipaddress.ip_address(host).compressed
+    except ValueError:
+        pass
+
+    if len(host) > 253:
+        raise ValueError("模拟器主机名过长")
+
+    hostname = host.rstrip(".")
+    if not hostname or any(not _HOSTNAME_LABEL.fullmatch(label) for label in hostname.split(".")):
+        raise ValueError("模拟器主机地址格式无效")
+    return hostname.lower()
+
+
+def build_adb_endpoint(host: str, port: int) -> str:
+    """构建 adbutils 可使用的 TCP 设备序列号。"""
+    normalized_host = normalize_adb_host(host)
+    try:
+        normalized_port = int(port)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("模拟器 ADB 端口必须是整数") from exc
+    if not 1 <= normalized_port <= 65535:
+        raise ValueError("模拟器 ADB 端口必须在 1 到 65535 之间")
+
+    try:
+        is_ipv6 = ipaddress.ip_address(normalized_host).version == 6
+    except ValueError:
+        is_ipv6 = False
+    endpoint_host = f"[{normalized_host}]" if is_ipv6 else normalized_host
+    return f"{endpoint_host}:{normalized_port}"


### PR DESCRIPTION
## 主要变更

- 支持通过 ADB 地址和端口连接远程安卓模拟器。
- 新增任务卡死超时设置，默认 600 秒。
- 新增全局服务器错误重试线程。
- 修复重试线程与 MuMu 输入并发导致的 `This event loop is already running`。
- 增加相关测试。