### PR TITLE
fix(mirror): 修正mirror/get_which_floor函数的楼层识别异常

### DIFF
--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -1533,7 +1533,7 @@ class Mirror:
                 find_type="image_with_multiple_targets",
                 my_crop=floor_progress_crop,
                 take_screenshot=True,
-                min_dist=30
+                min_dist= 80 * scale
             )
             not_passed_floor_count = len(not_passed_floors)
             self.floor = 5 - not_passed_floor_count


### PR DESCRIPTION
**[DEBUG] 2026-08-01 01:44:02,568 [AALC] tasks\mirror\mirror.py:1537: 找到8个目标：[(961, 518), (1066, 519), (856, 518), (1171, 519), (993, 518), (1098, 518), (888, 518), (1203, 519)]
[DEBUG] 2026-08-01 01:44:02,569 [AALC] tasks\mirror\mirror.py:1546: 当前镜牢层数: -3**
dark主题下用cv2识别楼层数 ？？/？？主副峰间距平均在32>30导致识别数目为实际的两倍
修改get_which_floor的min_dist为80*scale（scale=cfg.set_win_size/1440)
