### PR TITLE
⚙️ chore(input_handlers): 优化列表滚动实现以停止惯性滑动

### DIFF
--- a/module/automation/input_handlers/__init__.py
+++ b/module/automation/input_handlers/__init__.py
@@ -82,7 +82,8 @@ class AbstractInput:
     def mouse_swipe_for_scroll(self, x, y, duration=0.3, dx=0, dy=0, move_back=True) -> None:
         """各输入适配器必须实现的列表滚动手势。
 
-        手势按下后快速脱离长按判定区域，并在到达终点后立即抬起。
+        手势按下后快速脱离长按判定区域，到达终点后短暂停留以停止列表惯性再抬起。
+        停留时长低于长按排序判定阈值，不会触发队伍拖拽排序。
         此处是接口占位；实际输入由具体适配器实现。
         """
         raise InterruptedError(

--- a/module/automation/input_handlers/input.py
+++ b/module/automation/input_handlers/input.py
@@ -220,6 +220,7 @@ class Input(WinAbstractInput, metaclass=SingletonMeta):
         pyautogui.mouseDown()
         for point, move_duration in plan[1:]:
             pyautogui.moveTo(*point, duration=move_duration)
+        sleep(0.3)  # 原地停留停止列表惯性，低于长按排序判定阈值
         pyautogui.mouseUp()
 
         if move_back and current_mouse_position:
@@ -428,6 +429,7 @@ class BackgroundInput(WinAbstractInput, metaclass=SingletonMeta):
         self.mouse_down(*plan[0][0])
         for point, move_duration in plan[1:]:
             self.set_mouse_pos(*point, duration=move_duration)
+        sleep(0.3)  # 原地停留停止列表惯性，低于长按排序判定阈值
         self.mouse_up(*plan[-1][0])
 
         if move_back and current_mouse_position:
@@ -703,6 +705,7 @@ class WindowMoveInput(WinAbstractInput, metaclass=SingletonMeta):
         self.mouse_down(*plan[0][0])
         for point, move_duration in plan[1:]:
             self._window_move_to(*point, duration=move_duration)
+        sleep(0.3)  # 原地停留停止列表惯性，低于长按排序判定阈值
         self.mouse_up(*plan[-1][0])
         screen.handle.set_window_pos(*pos)
 

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -1059,7 +1059,7 @@ class MumuControl(AbstractInput):
 
             # Keep the release stationary long enough to stop list momentum, but
             # well below mouse_drag's old 500 ms hold that could reorder a team.
-            time.sleep(0.200)
+            time.sleep(0.300)
         finally:
             self.up()
 


### PR DESCRIPTION
-【优化】更新 `mouse_swipe_for_scroll` 接口文档，说明在终点短暂停留以停止列表惯性，且停留时长低于长按排序判定阈值。 -【优化】调整模拟器输入适配器中滚动结束后的停留时间，从 0.2 秒增加至 0.3 秒，以确保充分停止列表惯性。 -【优化】在桌面输入适配器和窗口输入适配器的滚动实现中添加 0.3 秒的原地停留，防止列表惯性滑动，同时避免触发拖拽排序。