### PR TITLE
fix(select_theme_pack): add sleep delays for theme pack loading animation

### DIFF
--- a/tasks/mirror/select_theme_pack.py
+++ b/tasks/mirror/select_theme_pack.py
@@ -73,6 +73,7 @@ def select_theme_pack(hard_switch=False, floor=None, team_num=None, use_custom_t
         # 切换难度
         if hard_switch:
             if auto.click_element("mirror/theme_pack/normal_assets.png"):
+                sleep(2) # 等待卡包加载动画完成
                 continue
             elif difficulty == "normal":
                 normal_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/theme_pack/normal_assets.png"))
@@ -80,8 +81,11 @@ def select_theme_pack(hard_switch=False, floor=None, team_num=None, use_custom_t
                     (normal_bbox[0] + normal_bbox[2]) // 2,
                     (normal_bbox[1] + normal_bbox[3]) // 2,
                 )
+                sleep(2) # 等待卡包加载动画完成
+                continue
         else:
             if auto.click_element("mirror/theme_pack/hard_assets.png"):
+                sleep(2) # 等待卡包加载动画完成
                 continue
             elif difficulty == "hard":
                 hard_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/theme_pack/hard_assets.png"))
@@ -89,6 +93,8 @@ def select_theme_pack(hard_switch=False, floor=None, team_num=None, use_custom_t
                     (hard_bbox[0] + hard_bbox[2]) // 2,
                     (hard_bbox[1] + hard_bbox[3]) // 2,
                 )
+                sleep(2) # 等待卡包加载动画完成
+                continue
 
         try:
             if floor == 4 and cfg.select_event_pack:

--- a/tasks/mirror/select_theme_pack.py
+++ b/tasks/mirror/select_theme_pack.py
@@ -73,7 +73,7 @@ def select_theme_pack(hard_switch=False, floor=None, team_num=None, use_custom_t
         # 切换难度
         if hard_switch:
             if auto.click_element("mirror/theme_pack/normal_assets.png"):
-                sleep(2) # 等待卡包加载动画完成
+                sleep(2)  # 等待卡包加载动画完成
                 continue
             elif difficulty == "normal":
                 normal_bbox = ImageUtils.get_bbox(ImageUtils.load_image("mirror/theme_pack/normal_assets.png"))


### PR DESCRIPTION
队伍采用普通，但是镜牢1层初始位于困难。切换难度失败。原因是切换后，未等待页面加载完。
此外，卡包回正大约花费2s


https://github.com/user-attachments/assets/66b98247-25e9-4d8a-bf2d-ebb161fc8b48

