### PR TITLE
⚙️ chore(resource-sync): 测试版跳过图片资源同步门禁

### DIFF
--- a/app/resource_sync_coordinator.py
+++ b/app/resource_sync_coordinator.py
@@ -172,7 +172,18 @@ class ResourceSyncCoordinator(QObject):
         返回:
             若允许继续执行资源同步则返回 True，否则返回 False。
         """
-        # 第一步：若软件更新检查失败，则直接阻断资源同步，避免在版本状态未知时覆盖资源。
+        # 第一步：测试版不参与图片资源同步，直接放行启动链路。
+        if getattr(update_thread, "is_prerelease", False):
+            log.info(f"当前软件版本 {cfg.version} 为测试版本，跳过图片资源同步")
+            if notify_user:
+                self._show_resource_sync_infobar(
+                    level="info",
+                    title=self._window.tr("无法同步图片资源"),
+                    content=self._window.tr("当前为测试版本，不参与图片资源同步"),
+                )
+            return False
+
+        # 第二步：若软件更新检查失败，则直接阻断资源同步，避免在版本状态未知时覆盖资源。
         latest_version = update_thread.new_version or self._window.tr("未知版本")
         if status is UpdateStatus.FAILURE:
             log.warning("无法确认当前软件是否为最新版本，已跳过图片资源同步")
@@ -184,7 +195,7 @@ class ResourceSyncCoordinator(QObject):
                 )
             return False
 
-        # 第二步：若本地软件版本尚未追平最新版本，则阻断资源同步并给出原因。
+        # 第三步：若本地软件版本尚未追平最新版本，则阻断资源同步并给出原因。
         if not getattr(update_thread, "is_current_version_latest", False):
             log.info(f"当前软件版本 {cfg.version} 与最新版本 {latest_version} 不一致，已跳过图片资源同步")
             if notify_user:

--- a/module/update/check_update.py
+++ b/module/update/check_update.py
@@ -79,6 +79,8 @@ class UpdateThread(QThread):
         current_version = parse(cfg.version.lstrip("Vv"))
         latest_version = parse(version.lstrip("Vv"))
         self.is_current_version_latest = current_version == latest_version
+        # 记录本地版本是否为预发布版（alpha/beta/rc），供资源同步门禁跳过测试版。
+        self.is_prerelease = current_version.is_prerelease
         return current_version, latest_version
 
     def _build_release_note_content(self, raw_content: str) -> str:


### PR DESCRIPTION
-【新增】在版本检查中记录本地版本是否为预发布版（alpha/beta/rc）。
-【优化】资源同步协调器增加测试版判断，跳过图片资源同步并提示用户。