### PR TITLE
fix(retry): 在收尾动作前停止全局重试监控

### DIFF
--- a/tasks/base/script_task_scheme.py
+++ b/tasks/base/script_task_scheme.py
@@ -427,6 +427,9 @@ def script_task() -> None | int:
 
     should_exit_aalc = False
     if platform.system() == "Windows":
+        # 收尾动作可能主动关闭游戏或模拟器。先停止截图监控，避免设备消失
+        # 被误判为断链并触发自动恢复，重新拉起刚关闭的模拟器。
+        retry_monitor.stop()
         actions, power_action = get_after_completion_config()
         try:
             should_exit_aalc = execute_after_completion(actions, power_action)


### PR DESCRIPTION
## 概述

修复任务完成后关闭游戏或模拟器时，全局重试监控仍在截图并可能触发连接恢复的问题。

## 主要改动

- 在 Windows 收尾动作执行前停止 `retry_monitor`。
- 避免退出游戏或模拟器造成的设备消失被误判为断链，从而重新拉起刚关闭的模拟器。
- 保留脚本线程 `finally` 中原有的停止调用；重复停止是幂等的，继续覆盖异常退出路径。

## 验证

- 当前 PR 文件树执行 `uv run pytest -ra`：17 passed
- “监控停止早于退出动作”生命周期回归测试在本地运行：1 passed；行为测试未包含在 PR 中
- `python -m compileall -q module tasks tests` 通过
- `ruff check tasks/base/script_task_scheme.py` 通过
- `git diff --check upstream/main...HEAD` 通过

## 已知限制

- CI 不包含真实模拟器退出与后台截图并发场景，已通过本地调用顺序回归验证。
