### PR TITLE
🐛 fix(updater): 扩展进程终止范围以覆盖安装目录内进程

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -254,8 +254,15 @@ class Updater:
     def terminate_processes(self):
         """终止相关进程以准备更新。"""
         print("开始终止进程...")
+        install_root = os.path.normcase(os.path.abspath(self.cover_folder_path)) + os.sep
         for proc in psutil.process_iter(attrs=["pid", "name"]):
-            if proc.info["name"] in self.process_names or any(name in proc.info["name"] for name in self.process_names):
+            try:
+                exe_path = proc.exe()
+            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                continue
+            # 覆盖 AALC 及安装目录内的附属进程（如 adb 服务），否则其可执行文件会被占用无法覆盖
+            is_install_binary = os.path.normcase(exe_path).startswith(install_root)
+            if proc.info["name"] in self.process_names or any(name in proc.info["name"] for name in self.process_names) or is_install_binary:
                 try:
                     proc.terminate()
                     try:


### PR DESCRIPTION
- 【优化】在 terminate_processes 方法中获取进程可执行文件路径，并检查其是否位于安装目录内。
- 【修复】对于安装目录内的附属进程（如 adb 服务），确保其可执行文件不被占用，以便顺利覆盖更新。
- 【健壮性】添加异常处理，跳过无法访问或已不存在的进程，避免更新过程中断。