### PR TITLE
⚙️ chore(updater): 更新进程终止逻辑以保护更新器自身

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -256,6 +256,8 @@ class Updater:
         print("开始终止进程...")
         install_root = os.path.normcase(os.path.abspath(self.cover_folder_path)) + os.sep
         for proc in psutil.process_iter(attrs=["pid", "name"]):
+            if proc.pid == os.getpid():
+                continue  # 更新器自身位于 update_temp（安装根目录内），不能杀自己
             try:
                 exe_path = proc.exe()
             except (psutil.AccessDenied, psutil.NoSuchProcess):


### PR DESCRIPTION
- 【修复】在终止旧版本进程时，跳过更新器自身的PID，防止杀进程逻辑误杀自身导致更新中断
- 【优化】补充注释说明更新器位于安装根目录内的update_temp，需要排除自身进程