### PR TITLE
fix: 修复在开启"小指良单通"下会因检测战力退出镜牢的问题 | 修改选择连续守备回合的下拉框距离更短 

### DIFF
--- a/app/team_setting_card.py
+++ b/app/team_setting_card.py
@@ -958,7 +958,7 @@ class CustomizeSettingsModule(QFrame):
         self.features_patch_line_1.addWidget(self.aggressive_save_systems)
         self.features_patch_line_1.addWidget(self.defense_first_round)
         self.features_patch_line_1.addWidget(self.defense_for_solo)
-        self.features_patch_line_1.addWidget(self.defense_for_solo_turns)
+        self.defense_for_solo.hBoxLayout.addWidget(self.defense_for_solo_turns, alignment=Qt.AlignmentFlag.AlignLeft)
 
         self.star_list.addWidget(self.starlight_select_all_wrapper, 0, 0)
         self.star_list.addWidget(self.starlight_clear_button_wrapper, 0, 1)

--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -74,7 +74,10 @@ class Mirror:
         self.observe_ego_gift_selected = team_setting.observe_ego_gift_selected  # 用户选择的观测EGO饰品列表
 
         self.defense_first_round = team_setting.defense_first_round  # 是否第一回合全员防御
-        self.defense_for_solo_state = DefenseForSoloState(team_setting.defense_for_solo_turns) if team_setting.defense_for_solo else None
+        self.defense_for_solo = team_setting.defense_for_solo  # 是否小指良单通连续防御
+        self.defense_for_solo_state = (
+            DefenseForSoloState(team_setting.defense_for_solo_turns) if team_setting.defense_for_solo else None
+        )
 
         self.start_time = time.time()
         self.first_battle = True  # 判断是否首次进入战斗，如果是则重新配队
@@ -330,10 +333,14 @@ class Mirror:
                     self.first_battle = True
                     continue
                 # 如果未开启战斗直至全灭，则检测罪人幸存人数是否少于10人
-                if not cfg.fight_to_last_man and not (
-                    auto.find_element("teams/12_sinner_live_assets.png")
-                    or auto.find_element("teams/11_sinner_live_assets.png")
-                    or auto.find_element("teams/10_sinner_live_assets.png")
+                if (
+                    not cfg.fight_to_last_man
+                    and not self.defense_for_solo
+                    and not (
+                        auto.find_element("teams/12_sinner_live_assets.png")
+                        or auto.find_element("teams/11_sinner_live_assets.png")
+                        or auto.find_element("teams/10_sinner_live_assets.png")
+                    )
                 ):
                     continue_mirror = check_team()
                     # 如果还有至少5人能战斗就继续，不然就退出重开


### PR DESCRIPTION
fix #845

顺手改了一下下拉框的距离
<img width="585" height="85" alt="image" src="https://github.com/user-attachments/assets/6bb58439-5168-4ddc-b191-fc3b0b28092a" />
**↓**
<img width="431" height="99" alt="image" src="https://github.com/user-attachments/assets/5d562d99-d628-4eea-8343-54197270a2c5" />
