### PR TITLE
fix(mumu): 修正 MuMu 编队列表误拖拽、惯性漂移及队伍定位偏差

### DIFF
--- a/module/automation/input_handlers/__init__.py
+++ b/module/automation/input_handlers/__init__.py
@@ -89,6 +89,12 @@ class AbstractInput:
             f"输入适配器 {self.__class__.__name__} 未实现 mouse_swipe_for_scroll"
         )
 
+    def mouse_swipe_for_team_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        """滚动编队列表；适配器可覆盖以规避队伍拖拽判定。"""
+        self.mouse_swipe_for_scroll(x, y, duration, dx, dy, move_back)
+
     def mouse_drag_down(self, x, y, reverse=1, move_back=True) -> None:
         """鼠标从指定位置向下拖动
 

--- a/module/automation/input_handlers/simulator/mumu_control.py
+++ b/module/automation/input_handlers/simulator/mumu_control.py
@@ -22,6 +22,7 @@ from module.my_error.my_error import userStopError
 from utils.utils import run_as_user
 
 from .. import AbstractInput
+from ..scroll_swipe import build_scroll_swipe_plan
 from . import insert_swipe
 
 usual_key_code = {
@@ -73,6 +74,11 @@ usual_key_code = {
     "ctrl": 29,
     "alt": 56,
 }
+
+MUMU_TEAM_SCROLL_ESCAPE_DISTANCE_AT_1080P = 60
+MUMU_TEAM_SCROLL_ESCAPE_HOLD_DURATION = 0.1
+MUMU_TEAM_SCROLL_SETTLE_DURATION = 0.5
+MUMU_TEAM_SCROLL_SETTLE_STEP_DURATION = 0.05
 
 
 class NemuIpcIncompatible(Exception):
@@ -1201,9 +1207,78 @@ class MumuControl(AbstractInput):
                 self.down(*point)
                 time.sleep(0.020)
 
-            # Keep the release stationary long enough to stop list momentum, but
-            # well below mouse_drag's old 500 ms hold that could reorder a team.
             time.sleep(0.200)
+        finally:
+            self.up()
+
+    def mouse_swipe_for_team_scroll(
+        self, x, y, duration=0.3, dx=0, dy=0, move_back=True
+    ) -> None:
+        """Scroll the team list without triggering team reordering or momentum."""
+        distance = (dx**2 + dy**2) ** 0.5
+        if distance == 0:
+            return
+
+        escape_distance = (
+            MUMU_TEAM_SCROLL_ESCAPE_DISTANCE_AT_1080P * cfg.set_win_size / 1080
+        )
+        unit_x = dx / distance
+        unit_y = dy / distance
+        # Upward page swipes must begin inside the visible team rows. Downward
+        # reset swipes shift their touch point instead, keeping the endpoint
+        # inside the client while preserving the same post-escape distance.
+        shift_start = dy > 0
+        touch_x = x - unit_x * escape_distance if shift_start else x
+        touch_y = y - unit_y * escape_distance if shift_start else y
+        plan = build_scroll_swipe_plan(
+            touch_x,
+            touch_y,
+            dx + unit_x * escape_distance,
+            dy + unit_y * escape_distance,
+            duration,
+            escape_distance=escape_distance,
+            escape_duration=0,
+        )
+        start = plan[0][0]
+        self.down(*start)
+        try:
+            if len(plan) > 1:
+                escape, escape_duration = plan[1]
+                time.sleep(escape_duration)
+                self.down(*escape)
+                # Give the game one render frame to recognize this as a scroll
+                # before measuring the remaining, row-accurate part of the drag.
+                time.sleep(MUMU_TEAM_SCROLL_ESCAPE_HOLD_DURATION)
+
+                end, remaining_duration = plan[-1]
+                if end != escape:
+                    move_x = end[0] - escape[0]
+                    move_y = end[1] - escape[1]
+                    point_spacing = 8 * cfg.set_win_size / 1080
+                    segment_count = max(
+                        int((move_x**2 + move_y**2) ** 0.5 / point_spacing),
+                        1,
+                    )
+                    segment_duration = remaining_duration / segment_count
+                    for step in range(1, segment_count + 1):
+                        time.sleep(segment_duration)
+                        ratio = step / segment_count
+                        self.down(
+                            escape[0] + move_x * ratio,
+                            escape[1] + move_y * ratio,
+                        )
+
+            if len(plan) > 1:
+                end = plan[-1][0]
+                settle_steps = round(
+                    MUMU_TEAM_SCROLL_SETTLE_DURATION
+                    / MUMU_TEAM_SCROLL_SETTLE_STEP_DURATION
+                )
+                # Refresh the stationary contact while holding it. MuMu's
+                # velocity tracker then sees an explicit zero-speed tail.
+                for _ in range(settle_steps):
+                    time.sleep(MUMU_TEAM_SCROLL_SETTLE_STEP_DURATION)
+                    self.down(*end)
         finally:
             self.up()
 

--- a/tasks/teams/team_formation.py
+++ b/tasks/teams/team_formation.py
@@ -1,3 +1,4 @@
+from math import ceil
 from time import sleep
 
 from module.automation import auto
@@ -5,13 +6,27 @@ from module.config import cfg
 from module.decorator.decorator import begin_and_finish_time_log
 from module.logger import log
 
-SIMULATOR_ORDERED_TEAM_PAGE_SWIPE_DISTANCE = 375
 WINDOWS_ORDERED_TEAM_PAGE_SWIPE_DISTANCE = 400
 NAMED_TEAM_PAGE_SWIPE_DISTANCE = 385
 TEAM_LIST_RESET_BOTTOM_MARGIN = 60
 ORDERED_TEAM_PAGE_SIZE = 5
 ORDERED_TEAM_COUNT = 40
 ORDERED_TEAM_VISIBLE_ROWS = 6
+ORDERED_TEAM_ROW_HEIGHT = 72.5
+SIMULATOR_ORDERED_TEAM_PAGE_SWIPE_DISTANCE = 375
+ORDERED_TEAM_LAST_PAGE_INDEX = (ORDERED_TEAM_COUNT - 1) // ORDERED_TEAM_PAGE_SIZE
+ORDERED_TEAM_LAST_PAGE_START = ORDERED_TEAM_COUNT - ORDERED_TEAM_VISIBLE_ROWS + 1
+ORDERED_TEAM_BOTTOM_PAGE_OFFSET = ORDERED_TEAM_ROW_HEIGHT / 2
+ORDERED_TEAM_PAGE_SWIPE_DISTANCE = ORDERED_TEAM_ROW_HEIGHT * ORDERED_TEAM_PAGE_SIZE
+ORDERED_TEAM_LAST_PAGE_SWIPE_DISTANCE = (
+    (
+        ORDERED_TEAM_LAST_PAGE_START
+        - 1
+        - (ORDERED_TEAM_LAST_PAGE_INDEX - 1) * ORDERED_TEAM_PAGE_SIZE
+    )
+    * ORDERED_TEAM_ROW_HEIGHT
+    - ORDERED_TEAM_BOTTOM_PAGE_OFFSET
+)
 
 
 # 清队
@@ -62,9 +77,13 @@ def team_formation(sinner_team):
         sleep(cfg.mouse_action_interval)
 
 
-def _ordered_team_page_swipe_distance():
+def _ordered_team_page_swipe_distance(page_index=None):
     if not cfg.simulator:
         return WINDOWS_ORDERED_TEAM_PAGE_SWIPE_DISTANCE
+    if getattr(cfg, "simulator_type", 10) == 0:
+        if page_index == ORDERED_TEAM_LAST_PAGE_INDEX:
+            return ORDERED_TEAM_LAST_PAGE_SWIPE_DISTANCE
+        return ORDERED_TEAM_PAGE_SWIPE_DISTANCE
     return SIMULATOR_ORDERED_TEAM_PAGE_SWIPE_DISTANCE
 
 
@@ -73,12 +92,27 @@ def _team_list_reset_swipe_distance(start_y, window_height, scale):
     return max(0, window_height - start_y - TEAM_LIST_RESET_BOTTOM_MARGIN * scale)
 
 
+def _team_list_reset_swipe_count(reset_distance, scale):
+    """Return enough reset swipes to cover all 40 rows from the bottom."""
+    scroll_extent = (
+        (ORDERED_TEAM_LAST_PAGE_START - 1) * ORDERED_TEAM_ROW_HEIGHT
+        - ORDERED_TEAM_BOTTOM_PAGE_OFFSET
+    ) * scale
+    return ceil(scroll_extent / max(reset_distance, 1))
+
+
 def _ordered_team_location(num):
     page_count = (num - 1) // ORDERED_TEAM_PAGE_SIZE
     logical_page_start = page_count * ORDERED_TEAM_PAGE_SIZE + 1
-    last_page_start = ORDERED_TEAM_COUNT - ORDERED_TEAM_VISIBLE_ROWS + 1
-    visible_page_start = min(logical_page_start, last_page_start)
+    visible_page_start = min(logical_page_start, ORDERED_TEAM_LAST_PAGE_START)
     return page_count, num - visible_page_start
+
+
+def _ordered_team_click_offset(page_count, team_order):
+    offset = ORDERED_TEAM_ROW_HEIGHT * team_order
+    if page_count == ORDERED_TEAM_LAST_PAGE_INDEX:
+        offset += ORDERED_TEAM_BOTTOM_PAGE_OFFSET
+    return offset
 
 
 @begin_and_finish_time_log(task_name="寻找队伍")
@@ -100,23 +134,32 @@ def select_battle_team(num):
         my_position[1] += position[1]
         auto.mouse_click(my_position[0], my_position[1])
         sleep(0.5)
-        reset_distance = _team_list_reset_swipe_distance(my_position[1], cfg.set_win_size, scale)
-        for _ in range(5):
-            auto.mouse_swipe_for_scroll(my_position[0], my_position[1], dy=reset_distance, duration=0.3)
+        reset_distance = _team_list_reset_swipe_distance(
+            my_position[1], cfg.set_win_size, scale
+        )
+        reset_swipe_count = _team_list_reset_swipe_count(reset_distance, scale)
+        for _ in range(reset_swipe_count):
+            auto.mouse_swipe_for_team_scroll(
+                my_position[0], my_position[1], dy=reset_distance, duration=0.3
+            )
         sleep(0.75)
         first_position = [position[0], position[1] + 70 * scale]
         if cfg.select_team_by_order:
             team_range, team_order = _ordered_team_location(num)
-            ordered_page_distance = _ordered_team_page_swipe_distance()
-            for _ in range(team_range):
-                auto.mouse_swipe_for_scroll(
+            for page_index in range(1, team_range + 1):
+                ordered_page_distance = _ordered_team_page_swipe_distance(page_index)
+                auto.mouse_swipe_for_team_scroll(
                     first_position[0],
                     first_position[1] + 375 * scale,
                     dy=-ordered_page_distance * scale,
                     duration=0.3,
                 )
                 sleep(1)
-            auto.mouse_click(first_position[0], first_position[1] + 75 * team_order * scale)
+            auto.mouse_click(
+                first_position[0],
+                first_position[1]
+                + _ordered_team_click_offset(team_range, team_order) * scale,
+            )
             log.info(f"成功找到队伍 # {num}")
             sleep(1)
             return True
@@ -131,7 +174,7 @@ def select_battle_team(num):
                     auto.mouse_action_with_pos(team_position, offset=False)
                     find = True
                     break
-                auto.mouse_swipe_for_scroll(
+                auto.mouse_swipe_for_team_scroll(
                     first_position[0],
                     first_position[1] + 375 * scale,
                     dy=-NAMED_TEAM_PAGE_SWIPE_DISTANCE * scale,


### PR DESCRIPTION
这是 #823 和 #840 的后续修正。MuMu 编队列表开始滑动时，如果触点移动不够快，游戏可能将操作识别为长按并拖拽队伍；到达目标位置后立即抬起，又可能因为惯性继续漂移。对于包含 40 个队伍的列表，误差也会在连续翻页后累积，最终点击到相邻队伍。

本次为编队列表增加 MuMu 专用滚动手势：按下后先快速脱离长按判定距离，到达目标位置后保持接触并持续发送静止坐标，确认列表停止后再抬起。普通 MuMu 列表滚动保持原有行为。

同时根据 40 个队伍、每页移动 5 行和可见 6 行的列表结构，统一计算 72.5 的队伍行高、完整翻页距离、末页距离、复位次数和最终点击位置。