### PR TITLE
⚙️ chore(mirror): 调整镜牢离开窗口按钮的识别阈值 fix #893

### DIFF
--- a/tasks/mirror/mirror.py
+++ b/tasks/mirror/mirror.py
@@ -255,7 +255,7 @@ class Mirror:
                 break
 
             # 离开镜牢的设置页面
-            if to_window_position := auto.find_element("mirror/road_in_mir/to_window_assets.png"):
+            if to_window_position := auto.find_element("mirror/road_in_mir/to_window_assets.png", threshold=0.75):
                 auto.mouse_click(to_window_position[0] - 200 * cfg.set_win_size / 1440, to_window_position[1])
                 continue
 
@@ -1136,7 +1136,7 @@ class Mirror:
                 break
             if auto.click_element("mirror/road_in_mir/towindow&forfeit_confirm_assets.png"):
                 break
-            if auto.click_element("mirror/road_in_mir/to_window_assets.png"):
+            if auto.click_element("mirror/road_in_mir/to_window_assets.png", threshold=0.75):
                 continue
             if auto.click_element("mirror/road_in_mir/setting_assets.png"):
                 sleep(1)


### PR DESCRIPTION
- 【优化】降低 to_window_assets.png 图像匹配阈值至 0.75，提升在不同分辨率下的识别成功率
- 【修复】修复设置页面和结算界面中离开窗口按钮可能识别失败的问题